### PR TITLE
Bugfix #34

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -207,9 +207,10 @@ class Manager(object):
                     #    - but if the system clock was adjusted halfway through
                     #      the interval, the CPM will be too low.
                     # The second one is more acceptable.
-                    self.vprint(3, 'this_start = {}, this_end = {}'.format(
-                        datetime_from_epoch(this_start),
-                        datetime_from_epoch(this_end)))
+                    self.vprint(
+                        3, 'former this_start = {}, this_end = {}'.format(
+                            datetime_from_epoch(this_start),
+                            datetime_from_epoch(this_end)))
                     this_start, this_end = self.get_interval(
                         time.time() - self.interval)
 
@@ -241,7 +242,11 @@ class Manager(object):
             # this shouldn't happen now that SleepError is raised and handled
             raise RuntimeError
         time.sleep(sleeptime)
-        if time.time() - end_time > 5 or time.time() < end_time:
+        now = time.time()
+        self.vprint(
+            3, 'sleep_until offset is {} seconds'.format(now - end_time))
+        # if the clock hasn't changed, this offset should be very small
+        if now - end_time > 5 or now < end_time:
             # raspberry pi clock reset during this interval
             # normally the first half of the condition triggers it.
             raise SleepError

--- a/manager.py
+++ b/manager.py
@@ -237,11 +237,14 @@ class Manager(object):
 
         sleeptime = end_time - time.time()
         self.vprint(3, 'Sleeping for {} seconds'.format(sleeptime))
-        if sleeptime < 0 or sleeptime < self.interval - 5:
-            # raspberry pi clock reset during this interval
-            raise SleepError
+        if sleeptime < 0:
+            # this shouldn't happen now that SleepError is raised and handled
+            raise RuntimeError
         time.sleep(sleeptime)
-        assert time.time() > end_time
+        if time.time() - end_time > 5 or time.time() < end_time:
+            # raspberry pi clock reset during this interval
+            # normally the first half of the condition triggers it.
+            raise SleepError
 
     def get_interval(self, start_time):
         """

--- a/manager.py
+++ b/manager.py
@@ -195,12 +195,20 @@ class Manager(object):
                 except SleepError:
                     self.vprint(1, 'SleepError: system clock skipped ahead!')
                     # the previous start/end times are meaningless.
-                    #   so, start over.
-                    this_start, this_end = self.get_interval(time.time())
-                    self.sleep_until(this_end)
-                else:
-                    self.handle_cpm(this_start, this_end)
-                    this_start, this_end = self.get_interval(this_end)
+                    # There are a couple ways this could be handled.
+                    # 1. keep the same start time, but go until time.time()
+                    #    - but if there was actually an execution delay,
+                    #      the CPM will be too high.
+                    # 2. set start time to be time.time() - interval,
+                    #    and end time is time.time().
+                    #    - but if the system clock was adjusted halfway through
+                    #      the interval, the CPM will be too low.
+                    # The second one is more acceptable.
+                    this_start, this_end = self.get_interval(
+                        time.time() - self.interval)
+
+                self.handle_cpm(this_start, this_end)
+                this_start, this_end = self.get_interval(this_end)
         except KeyboardInterrupt:
             self.vprint(1, '\nKeyboardInterrupt: stopping Manager run')
             self.stop()

--- a/manager.py
+++ b/manager.py
@@ -244,9 +244,11 @@ class Manager(object):
         time.sleep(sleeptime)
         now = time.time()
         self.vprint(
-            3, 'sleep_until offset is {} seconds'.format(now - end_time))
-        # if the clock hasn't changed, this offset should be very small
-        if now - end_time > 5 or now < end_time:
+            2, 'sleep_until offset is {} seconds'.format(now - end_time))
+        # normally this offset is < 0.1 s
+        # although a reboot normally produces an offset of 9.5 s
+        #   on the first cycle
+        if now - end_time > 10 or now < end_time:
             # raspberry pi clock reset during this interval
             # normally the first half of the condition triggers it.
             raise SleepError

--- a/manager.py
+++ b/manager.py
@@ -190,10 +190,10 @@ class Manager(object):
 
         try:
             while self.running:
+                self.vprint(3, 'Sleeping at {} until {}'.format(
+                    datetime_from_epoch(time.time()),
+                    datetime_from_epoch(this_end)))
                 try:
-                    self.vprint(3, 'Sleeping at {} until {}'.format(
-                        datetime_from_epoch(time.time()),
-                        datetime_from_epoch(this_end)))
                     self.sleep_until(this_end)
                 except SleepError:
                     self.vprint(1, 'SleepError: system clock skipped ahead!')

--- a/manager.py
+++ b/manager.py
@@ -222,7 +222,7 @@ class Manager(object):
         """
 
         sleeptime = end_time - time.time()
-        if sleeptime < 290:
+        if sleeptime < 0 or sleeptime < self.interval - 5:
             # raspberry pi clock reset during this interval
             raise SleepError
         time.sleep(sleeptime)

--- a/manager.py
+++ b/manager.py
@@ -191,6 +191,9 @@ class Manager(object):
         try:
             while self.running:
                 try:
+                    self.vprint(3, 'Sleeping at {} until {}'.format(
+                        datetime_from_epoch(time.time()),
+                        datetime_from_epoch(this_end)))
                     self.sleep_until(this_end)
                 except SleepError:
                     self.vprint(1, 'SleepError: system clock skipped ahead!')
@@ -204,6 +207,9 @@ class Manager(object):
                     #    - but if the system clock was adjusted halfway through
                     #      the interval, the CPM will be too low.
                     # The second one is more acceptable.
+                    self.vprint(3, 'this_start = {}, this_end = {}'.format(
+                        datetime_from_epoch(this_start),
+                        datetime_from_epoch(this_end)))
                     this_start, this_end = self.get_interval(
                         time.time() - self.interval)
 
@@ -230,6 +236,7 @@ class Manager(object):
         """
 
         sleeptime = end_time - time.time()
+        self.vprint(3, 'Sleeping for {} seconds'.format(sleeptime))
         if sleeptime < 0 or sleeptime < self.interval - 5:
             # raspberry pi clock reset during this interval
             raise SleepError

--- a/sensor.py
+++ b/sensor.py
@@ -111,6 +111,7 @@ class Sensor(object):
         # watching for stray errors... (temp?)
         try:
             # add to queue. (usually takes ~10 us)
+            now = time.time()
             self.counts.append(now)
 
             # display(s)

--- a/sensor.py
+++ b/sensor.py
@@ -110,18 +110,13 @@ class Sensor(object):
 
         # watching for stray errors... (temp?)
         try:
-            # add to queue
-            now = time.time()
+            # add to queue. (usually takes ~10 us)
             self.counts.append(now)
-            now2 = time.time()
 
             # display(s)
             self.vprint(1, '\tCount at {}'.format(datetime_from_epoch(now)))
             if self.LED:
                 self.LED.flash()
-            self.vprint(
-                3, '    Adding count to queue took no more than {} s'.format(
-                    (now2 - now)))
         except:
             if self.logfile:
                 with open(self.logfile, 'a') as f:


### PR DESCRIPTION
Fixes the `IOError` issue we saw at James Logan and East Bay Innovation Academy. It was caused by the pi clock getting way out of sync while the system is powered off.

Long term, with buffered data and local storage, we need a better solution. Probably wait until NTP finishes syncing before starting our code. Either wait for NTP in bash, or in python.
