### PR TITLE
Network config

### DIFF
--- a/station-update.py
+++ b/station-update.py
@@ -18,7 +18,7 @@ print 'csv file name: ', NAME
 
 args1 = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
 args2 = '/home/pi/config/config.csv'
-print 'scp' args1 + args2
+print 'scp', args1, args2
 
 # Execute the linux command line and wait until it executes for the script to continue.
 p = Popen("scp", args1, args2).wait()

--- a/station-update.py
+++ b/station-update.py
@@ -41,7 +41,7 @@ ID = raw_input('What is the station ID?: ')
 Loop through each line of the interfaces file to find the default station ID placeholder and replace it with the station ID provided
 by the user.
 '''
-for line in fileinput.input('/etc/network/interfaces', inplace=1, backup='.bak'):
+for line in fileinput.input('/etc/network/interfaces'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
     if 'wireless-essid' in line:
         # Create a handle for a new line with the updated station ID to input into the interfaces file.      

--- a/station-update.py
+++ b/station-update.py
@@ -34,7 +34,7 @@ Part 2: Updating the dosimeter ID on the network configuration file on the Pi-ha
 ID = raw_input('What is the station ID?: ')
 
 # Open the interfaces file (and call a file handle for it within the program) and update the network ID.
-with open('/etc/network/interfaces', 'r+') as netConfig:
+with open('/etc/network/interfaces.d', 'r+') as netConfig:
   # Search line by line in the interfaces file.
   for line in netConfig:
     # Search for 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.

--- a/station-update.py
+++ b/station-update.py
@@ -301,7 +301,7 @@ elif setup_static_ip.lower() == 'y':
 
             # Update the interfaces file with the static IP by commenting out
             # the static IP call.
-            interfaces_update('  address {}'.format(netmask_id), '#   ' +
+            interfaces_update('  address {}'.format(ip_static), '#   ' +
                               'address\n')
 
             print('\nA static IP has not been set (requires a netmask, ' +
@@ -382,7 +382,7 @@ elif setup_static_ip.lower() == 'y':
 
             # Update the interfaces file with the static IP by commenting out
             # the static IP call.
-            interfaces_update('  address {}'.format(netmask_id), '#   ' +
+            interfaces_update('  address {}'.format(ip_static), '#   ' +
                               'address\n')
 
             # Update the interfaces file with the netmask identifier by
@@ -469,7 +469,7 @@ elif setup_static_ip.lower() == 'y':
 
             # Update the interfaces file with the static IP by commenting out
             # the static IP call.
-            interfaces_update('  address {}'.format(netmask_id), '#   ' +
+            interfaces_update('  address {}'.format(ip_static), '#   ' +
                               'address\n')
 
             # Remove the netmask and gateway identifiers from the interfaces

--- a/station-update.py
+++ b/station-update.py
@@ -52,7 +52,7 @@ for line in fileinput.input('/etc/network/interfaces'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
     if 'wireless-essid' in line:
         # Create a handle for a new line with the updated station ID to input into the interfaces file.      
-        line = '  wireless-essid RPiAdHocNetwork' + ID + '\n'
+        line = '  wireless-essid RPiAdHocNetwork' + ID
     
     # Write the new line with the updated station ID in the interfaces file.
     print(line)

--- a/station-update.py
+++ b/station-update.py
@@ -44,6 +44,8 @@ Define a function to update the interfaces file by replacing the line containing
 '''
 
 def interfacesUpdate(repPhrase, newLine):
+	'''
+	# METHOD 1
 	tempFile, tempPath = mkstemp()
 	
 	with open(tempPath, 'w') as tempInterfaces:
@@ -55,8 +57,10 @@ def interfacesUpdate(repPhrase, newLine):
 	
     	# Move the updated interfaces file to replace the old interfaces file using root access.
 	os.system('sudo mv %s /etc/network/interfaces' % tempPath)
+	'''
 	
 	'''
+	# METHOD 2
 	# Store the original standard input and output.
 	tempIn = sys.stdin
 	tempOut = sys.stdout

--- a/station-update.py
+++ b/station-update.py
@@ -107,7 +107,7 @@ If the response is a no, simply let the user know the script will henceforth
 assume that there is a csv file, and continue with the script.
 '''
 
-while csv_copy.lower() != 'y' or 'n':
+while csv_copy.lower() not 'y' or 'n':
 
     # Let the user know a valid response is required for the question.
     print('Please provide a valid "y" or "n" response.')

--- a/station-update.py
+++ b/station-update.py
@@ -14,7 +14,7 @@ from subprocess import Popen
 # Ask the user for the csv file name.
 NAME = input("What is the csv file name?:")
 
-print (NAME,"csv file name")
+print NAME,"csv file name"
 
 # Execute the linux command line and wait until it executes for the script to continue.
 p = Popen("scp", "dosenet@dosenet.dhcp.lbl.gov:~/config-files/", NAME, "/home/pi/config/config.csv").wait()

--- a/station-update.py
+++ b/station-update.py
@@ -34,7 +34,7 @@ Part 2: Updating the dosimeter ID on the network configuration file on the Pi-ha
 ID = raw_input('What is the station ID?: ')
 
 # Open the interfaces file (and call a file handle for it within the program) and update the network ID.
-with open('/etc/network/interfaces/interfaces', 'r+') as netConfig:
+with open('/etc/network/interfaces', 'r+') as netConfig:
   # Search line by line in the interfaces file.
   for line in netConfig:
     # Search for 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.

--- a/station-update.py
+++ b/station-update.py
@@ -53,7 +53,7 @@ for line in fileinput.input('/etc/network/interfaces'):
         line = '  wireless-essid RPiAdHocNetwork' + ID + '\n'
     
     # Write the new line with the updated station ID in the interfaces file.
-    sys.stdout.write(line)
+    print(line)
 
 l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
 

--- a/station-update.py
+++ b/station-update.py
@@ -86,7 +86,7 @@ setupStaticIP = raw_input('Do you want to set a static IP (Y/N)?: ')
 '''
 If the response is a yes, update the interfaces file to include the static IP and the relevant functionality.
 '''
-if setupStaticIP is 'Y' or 'y':
+if setupStaticIP == 'y':
 
 	# Ask for the static IP.
 	IP_static = raw_input('What is your static IP?: ')
@@ -115,13 +115,13 @@ if setupStaticIP is 'Y' or 'y':
 		interfacesUpdate('#   netmask', '  netmask %s' % netmask_ID)
 
 	# Ask the user if they have a gateway.
-	setupGateway = raw_input('Do you have a gateway (Y/N)?: ')
+	setupGateway = raw_input('Do you have a gateway (y/n)?: ')
 
 	'''
 	If the response is a yes, update the interfaces file to include the gateway identifier and the
 	relevant functionality.
 	'''
-	if setupGateway is 'Y' or 'y':
+	if setupGateway is 'y':
 
 		# Ask for the gateway identifier.
 		gateway_ID = raw_input('What is your gateway identifier?: ')

--- a/station-update.py
+++ b/station-update.py
@@ -168,9 +168,12 @@ if setup_static_ip is 'y':
         dns_server_2 = raw_input('What is the IP of the second DNS server?: ')
 
         # Update the interfaces file with the DNS server names by uncommenting
-        # out the DNS server names call.
+        # out the DNS server names call. Do it sequentially.
         interfaces_update('#   dns-nameservers ',
-                          '  dns-nameservers {} {}'.format(dns_server_1, dns_server_2) + '\n')
+                          '  dns-nameservers {}'.format(dns_server_1) + '\n')
+            
+        interfaces_update('#   dns-nameservers ',
+                          '  dns-nameservers {}'.format(dns_server_2) + '\n')
 
 # Ask the user if they would like to restore the backup to the network
 # interfaces file.

--- a/station-update.py
+++ b/station-update.py
@@ -34,7 +34,7 @@ Part 2: Updating the dosimeter ID on the network configuration file on the Pi-ha
 ID = raw_input('What is the station ID?: ')
 
 # Open the interfaces file (and call a file handle for it within the program) and update the network ID.
-with open('/etc/network/interfaces.d', 'r+') as netConfig:
+with open('/etc/network/interfaces', 'r+') as netConfig:
   # Search line by line in the interfaces file.
   for line in netConfig:
     # Search for 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.

--- a/station-update.py
+++ b/station-update.py
@@ -42,8 +42,9 @@ Loop through each line of the interfaces file to find the default station ID pla
 by the user.
 '''
 
-# Open the interfaces file for writing using the print statement.
-sys.stdout = open('/etc/network/interfaces', 'w')
+# Open the interfaces file for writing using the print statement and write to a temporary file.
+sys.stdin = open('/etc/network/interfaces', 'r')
+sys.stdout = open('/devel/dosenet-raspberrypi/interfaces_temp', 'w')
 
 for line in fileinput.input('/etc/network/interfaces'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
@@ -52,4 +53,9 @@ for line in fileinput.input('/etc/network/interfaces'):
         line = '  wireless-essid RPiAdHocNetwork' + ID + '\n'
     
     # Write the new line with the updated station ID in the interfaces file.
-    print line
+    sys.stdout.write(line)
+
+l = os.system('sudo mv /devel/dosenet-raspberrypi/interfaces_temp /etc/network/interfaces')
+
+# Print the scp linux command that was executed for debugging purposes.
+print 'FOR DEBUGGING, linux command: %s' % l

--- a/station-update.py
+++ b/station-update.py
@@ -88,7 +88,7 @@ print setupStaticIP
 '''
 If the response is a yes, update the interfaces file to include the static IP and the relevant functionality.
 '''
-if setupStaticIP == 'y':
+if setupStaticIP:
 	
 	print setupStaticIP
 

--- a/station-update.py
+++ b/station-update.py
@@ -103,8 +103,8 @@ def dynamic_restore(static, netmask, gateway):
     Update the interfaces file with the dynamic IP by uncommenting out the
     dynamic IP call and commenting out the static IP calls.
     '''
-    interfaces_update('# replace for dynamic IP configuration' + '\n' +
-                      '# iface eth0 inet dhcp', 'iface eth0 inet dhcp\n')
+    interfaces_update('# replace for dynamic IP configuration', '')
+    interfaces_update('# iface eth0 inet dhcp', 'iface eth0 inet dhcp\n')
     interfaces_update('# auto eth0', 'auto eth0' + '\n')
     interfaces_update('iface eth0 inet static', '# iface eth0 inet static' +
                       '\n')

--- a/station-update.py
+++ b/station-update.py
@@ -15,7 +15,7 @@ from subprocess import Popen
 NAME = input('What is the csv file name?: ')
 
 # Print the csv file name inputed by the user for debugging purposes.
-print 'FOR DEGUBBING, csv file name: ', NAME
+print 'FOR DEGUBBING, csv file name: %s' % NAME
 
 # Define the paths to the source and target .csv files as arguments for the scp linux command to be executed through the Popen function.
 sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + str(NAME)

--- a/station-update.py
+++ b/station-update.py
@@ -170,7 +170,7 @@ if setup_static_ip is 'y':
         # Update the interfaces file with the DNS server names by uncommenting
         # out the DNS server names call.
         interfaces_update('#   dns-nameservers ', '  dns-nameservers ' +
-                          '{} {}'.format(dns_server_1, dns_server_2) + '\n')
+                          '{0} {1}'.format(dns_server_1, dns_server_2) + '\n')
 
 # Ask the user if they would like to restore the backup to the network
 # interfaces file.

--- a/station-update.py
+++ b/station-update.py
@@ -1,6 +1,6 @@
 # Author: Yaro Kaminskiy
 
-# Use the built-in subprocess module and open function to securely copy the Pi-hat network configuration file from the Dosenet servers
+# Use the built-in subprocess module and Popen function to securely copy the Pi-hat network configuration file from the Dosenet servers
 # to a Pi-hat at a school of interest and to update the network ID on the network configuration file for a Pi-hat using a search algorithm.
 
 '''
@@ -12,25 +12,27 @@ import os
 from subprocess import Popen
 
 # Ask the user for the csv file name.
-NAME = input("What is the csv file name?:")
+NAME = input("What is the csv file name?: ")
 
-print 'csv file name: ', NAME
+# Print the csv file name inputed by the user for debugging purposes.
+print 'FOR DEGUBBING, csv file name: ', NAME
 
-args1 = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
-args2 = '/home/pi/config/config.csv'
-print 'scp', args1, args2
+# Define the arguments to the scp linux command to be executed through the Popen function
+arg1 = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + str(NAME)
+arg2 = '/home/pi/config/config.csv'
 
-# Execute the linux command line and wait until it executes for the script to continue.
-p = Popen("scp", [args1 + ' ' + args2], bufsize=-1).wait()
+# Execute the linux command line. Wait until it executes for this Python script to continue.
+p = Popen(['scp', arg1, arg2]).wait()
 
-print ("linux command: ", p)
-
-# Ask for the station ID.
-ID = input("What is the station ID?:")
+# Print the scp linux command that was executed for debugging purposes.
+print 'FOR DEBUGGING, linux command: ', p
 
 '''
 Part 2: Updating the dosimeter ID on the network configuration file on the Pi-hat once it has been copied securely over the Internet.
 '''
+
+# Ask for the station ID.
+ID = input("What is the station ID?: ")
 
 # Open the relevant directory to read/write the network ID on the Pi-hat.
 dirConfig = os.open('/etc/network/interfaces')

--- a/station-update.py
+++ b/station-update.py
@@ -82,11 +82,15 @@ interfacesUpdate('wireless-essid RPiAdHocNetwork', '  wireless-essid RPiAdHocNet
 
 # Ask the user if they would like to use a static IP.
 setupStaticIP = raw_input('Do you want to set a static IP (Y/N)?: ')
+	
+print setupStaticIP
 
 '''
 If the response is a yes, update the interfaces file to include the static IP and the relevant functionality.
 '''
 if setupStaticIP == 'y':
+	
+	print setupStaticIP
 
 	# Ask for the static IP.
 	IP_static = raw_input('What is your static IP?: ')

--- a/station-update.py
+++ b/station-update.py
@@ -57,7 +57,7 @@ for line in fileinput.input('/etc/network/interfaces'):
     # Write the new line with the updated station ID in the interfaces file.
     print(line)
 
-l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
+l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces_test')
 
 sys.stdout.close()
 

--- a/station-update.py
+++ b/station-update.py
@@ -168,12 +168,9 @@ if setup_static_ip is 'y':
         dns_server_2 = raw_input('What is the IP of the second DNS server?: ')
 
         # Update the interfaces file with the DNS server names by uncommenting
-        # out the DNS server names call. Do it sequentially.
-        interfaces_update('#   dns-nameservers',
-                          '  dns-nameservers {}'.format(dns_server_2) + '\n')
-            
-        interfaces_update('  dns-nameservers ',
-                          '  dns-nameservers {} '.format(dns_server_1) + '\n')
+        # out the DNS server names call.
+        interfaces_update("#   dns-nameservers", "  dns-nameservers " +
+                          '{} {}'.format(dns_server_1, dns_server_2) + '\n')
 
 # Ask the user if they would like to restore the backup to the network
 # interfaces file.

--- a/station-update.py
+++ b/station-update.py
@@ -14,10 +14,12 @@ from subprocess import Popen
 # Ask the user for the csv file name.
 NAME = input("What is the csv file name?:")
 
-print ("csv file name: ", NAME)
+print 'csv file name: ', NAME
+
+
 
 # Execute the linux command line and wait until it executes for the script to continue.
-p = Popen("scp", "dosenet@dosenet.dhcp.lbl.gov:~/config-files/", NAME, "/home/pi/config/config.csv").wait()
+p = Popen("scp", ["dosenet@dosenet.dhcp.lbl.gov:~/config-files/", str(NAME), "/home/pi/config/config.csv").wait()
 
 print ("linux command: ", p)
 

--- a/station-update.py
+++ b/station-update.py
@@ -1,11 +1,11 @@
 """
 Network config updater for a DoseNet silicon radiation detector station.
 
-This script securely copies the Pi-hat network configuration file from the
-DoseNet servers to a Pi-hat at a school of interest and updates the network ID
-on the network configuration file for the Pi-hat, as well as handles netmasks,
-gateways, and DNS server names to setup a static IP if necessary. (A dynamic
-IP is set by default.)
+This script securely copies the Raspberry Pi network configuration file from
+the DoseNet servers to a detector at a school of interest and updates the
+network ID on the network configuration file for the Rasberry Pi, as well as
+handles netmasks, gateways, and DNS server names to setup a static IP if
+necessary. (A dynamic IP is set by default.)
 """
 
 # Import the relevant modules and functions from the appropriate libraries.
@@ -87,28 +87,65 @@ def backup_restore():
           'script again to setup the network configuration again.')
 
 '''
-Part 3: Securely copy the network configuration file from the Dosenet
-        servers to the Pi-hat.
+Part 3: Securely copy the network configuration (csv) file from the Dosenet
+        servers to the Raspberry Pi if the user so wishes.
 '''
 
-# Ask the user for the csv file name and output the raw input string as a
-# variable.
-name = raw_input('\nWhat is the csv file name?: ')
+# Ask the user if they would like to copy a new network configuration file
+# from the LBNL servers.
+csv_copy = raw_input('\nWould you like to copy a new network configuration ' +
+                     '(csv) file from the LBNL servers (y/n)?: ')
 
-# Define the paths to the source and target csv files as arguments for the scp
-# linux command to be executed through the os.system function. Note: A
-# password to the DoseNet servers in LBNL will be requested at this point in
-# the script.
-sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + name
-targetPath = '/home/pi/config/config.csv'
+'''
+If there is no valid response, let the user know and repeat the prompt until a
+valid response is provided.
 
-# Execute the scp linux command line to securely copy the file over the
-# Internet.
-os.system('scp {} {}'.format(sourcePath, targetPath))
+If the response is a yes, ask for the network configuration (csv) file name
+and securely copy it from the LBNL servers.
+
+If the response is a no, simply let the user know the script will henceforth
+assume that there is a csv file, and continue with the script.
+'''
+
+while csv_copy.lower() != 'y' or 'n':
+
+    # Let the user know a valid response is required for the question.
+    print('Please provide a valid "y" or "n" response.')
+
+    # Ask the user if they would like to copy a new network configuration file
+    # from the LBNL servers.
+    csv_copy = raw_input('\nWould you like to copy a new network ' +
+                         'configuration (csv) file from the LBNL servers ' +
+                         '(y/n)?: ')
+
+if csv_copy.lower() == 'y':
+
+    # Ask the user for the csv file name and output the raw input string as a
+    # variable.
+    name = raw_input('\nWhat is the network configuration (csv) file name?: ')
+
+    # Define the paths to the source and target csv files as arguments for the
+    # scp linux command to be executed through the os.system function. Note: A
+    # password to the DoseNet servers in LBNL will be requested at this point
+    # in the script.
+    sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + name
+    targetPath = '/home/pi/config/config.csv'
+
+    # Execute the scp linux command line to securely copy the file over the
+    # Internet.
+    os.system('scp {} {}'.format(sourcePath, targetPath))
+
+if csv_copy.lower() == 'n':
+
+    raw_input('\nNote: There must be a network configuration file to ' +
+              'properly configure the network options. Please double-check ' +
+              'before continuing. Exit and rerun the script to get a ' +
+              'prompt to copy the network configuration file. Press any ' +
+              'key to continue. ')
 
 '''
 Part 4: Update the dosimeter ID on the network configuration file on the
-        Pi-hat once it has been copied securely over the Internet.
+        Raspberry Pi once it has been copied securely over the Internet.
 '''
 
 # Backup the interfaces file through the cp linux command to make a backup copy

--- a/station-update.py
+++ b/station-update.py
@@ -21,7 +21,7 @@ args2 = '/home/pi/config/config.csv'
 print 'scp', args1, args2
 
 # Execute the linux command line and wait until it executes for the script to continue.
-p = Popen("scp", args1, args2).wait()
+p = Popen("scp", args1, args2, bufsize=-1).wait()
 
 print ("linux command: ", p)
 

--- a/station-update.py
+++ b/station-update.py
@@ -33,7 +33,7 @@ Part 2: Updating the dosimeter ID on the network configuration file on the Pi-ha
 os.system('sudo cp /etc/network/interfaces /etc/network/interfaces_backup')
 
 # Alert the user that a backup file has been made.
-print "A backup of the network interfaces file has been made. If you make an error during the rest of the setup, a prompt at the end will ask if you'd like to restore the backup."
+print 'A backup of the network interfaces file has been made. If you make an error during the rest of the setup, a prompt at the end will ask if you would like to restore the backup.'
 
 '''
 Define a function to update the interfaces file by replacing the line containing an indicated phrase with a new line.

--- a/station-update.py
+++ b/station-update.py
@@ -15,7 +15,7 @@ from subprocess import Popen
 NAME = input("What is the csv file name?:")
 
 # Execute the linux command line and wait until it executes for the script to continue.
-p = Popen("scp", ("dosenet@dosenet.dhcp.lbl.gov:~/config-files/" + NAME), "/home/pi/config/config.csv").wait()
+p = Popen("scp", "dosenet@dosenet.dhcp.lbl.gov:~/config-files/", NAME, "/home/pi/config/config.csv").wait()
 
 # Ask for the station ID.
 ID = input("What is the station ID?:")

--- a/station-update.py
+++ b/station-update.py
@@ -118,7 +118,11 @@ the changes done to the network interfaces file.
 If the response is a yes, update the interfaces file to include the static IP
 and the relevant functionality.
 '''
+print('\nFor debugging: ' + setup_static_ip)
+
 if setup_static_ip.lower() is 'n':
+
+    print('\nFor debugging: ' + setup_static_ip)
 
     # Ask the user if they would like to keep the changes to the network
     # interfaces file.

--- a/station-update.py
+++ b/station-update.py
@@ -34,7 +34,7 @@ Part 2: Updating the dosimeter ID on the network configuration file on the Pi-ha
 ID = raw_input('What is the station ID?: ')
 
 # Open the interfaces file (and call a file handle for it within the program) and update the network ID.
-with open('/etc/network/interfaces/interfaces', '+') as netConfig:
+with open('/etc/network/interfaces/interfaces', 'r+') as netConfig:
   # Search line by line in the interfaces file.
   for line in netConfig:
     # Search for 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.

--- a/station-update.py
+++ b/station-update.py
@@ -147,8 +147,6 @@ while csv_copy.lower() not in ('y', 'n'):
     # Let the user know a valid response is required for the question.
     print('Please provide a valid "y" or "n" response.')
 
-    print(csv_copy)
-
     # Ask the user if they would like to copy a new network configuration file
     # from the LBNL servers.
     csv_copy = raw_input('\nWould you like to copy a new network ' +

--- a/station-update.py
+++ b/station-update.py
@@ -107,7 +107,7 @@ If the response is a no, simply let the user know the script will henceforth
 assume that there is a csv file, and continue with the script.
 '''
 
-while (csv_copy.lower() != 'y') or (csv_copy.lower() != 'n'):
+while csv_copy.lower() not in ('y', 'n'):
 
     # Let the user know a valid response is required for the question.
     print('Please provide a valid "y" or "n" response.')

--- a/station-update.py
+++ b/station-update.py
@@ -118,11 +118,8 @@ the changes done to the network interfaces file.
 If the response is a yes, update the interfaces file to include the static IP
 and the relevant functionality.
 '''
-print('\nFor debugging: ' + setup_static_ip)
 
 if setup_static_ip.lower() == 'n':
-
-    print('\nFor debugging: ' + setup_static_ip)
 
     # Ask the user if they would like to keep the changes to the network
     # interfaces file.
@@ -136,7 +133,7 @@ if setup_static_ip.lower() == 'n':
     If the response is a no (or anything else), restore the backup to the
     network interfaces file.
     '''
-    if keep_changes.lower() == 'y':
+    if keep_changes.lower() is 'y':
 
         print('\nA dynamic IP has been set. Your Pi-hat sensor module now ' +
               'has updated network functionality and the appropriate ' +

--- a/station-update.py
+++ b/station-update.py
@@ -53,16 +53,16 @@ def interfacesUpdate(repPhrase, newLine):
 	for line in fileinput.input('/etc/network/interfaces'):
 
 		# Search and find the phrase of interest to indicate the place in the code to replace the original line with
-    	# the new line.
-    	if repPhrase in line:
+    		# the new line.
+    		if repPhrase in line:
 
-    	    # Create a handle for a new line with the updated phrase to input into the interfaces file.      
-    	    line = newLine
+    	    		# Create a handle for a new line with the updated phrase to input into the interfaces file.      
+    	    		line = newLine
     
-    	# Write the new line with the updated station ID in the temporary interfaces file.
-    	sys.stdout.write(line)
+    		# Write the new line with the updated station ID in the temporary interfaces file. Also copy all other lines.
+    		sys.stdout.write(line)
 
-    # Move the updated interfaces file to replace the old interfaces file using root access.
+    	# Move the updated interfaces file to replace the old interfaces file using root access.
 	l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
 
 	# Close the interfaces files for reading and writing

--- a/station-update.py
+++ b/station-update.py
@@ -169,7 +169,7 @@ if setup_static_ip is 'y':
 
         # Update the interfaces file with the DNS server names by uncommenting
         # out the DNS server names call. Do it sequentially.
-        interfaces_update('#   dns-nameservers ',
+        interfaces_update('#   dns-nameservers',
                           '  dns-nameservers {}'.format(dns_server_2) + '\n')
             
         interfaces_update('  dns-nameservers ',

--- a/station-update.py
+++ b/station-update.py
@@ -170,7 +170,7 @@ if setup_static_ip is 'y':
         # Update the interfaces file with the DNS server names by uncommenting
         # out the DNS server names call.
         interfaces_update("#   dns-nameservers", "  dns-nameservers " +
-                          '{} {}'.format(dns_server_1, dns_server_2) + '\n')
+                          "{} {}".format(dns_server_1, dns_server_2) + '\n')
 
 # Ask the user if they would like to restore the backup to the network
 # interfaces file.

--- a/station-update.py
+++ b/station-update.py
@@ -169,8 +169,8 @@ if setup_static_ip is 'y':
 
         # Update the interfaces file with the DNS server names by uncommenting
         # out the DNS server names call.
-        interfaces_update('#   dns-nameservers ', '  dns-nameservers ' +
-                          '{0} {1}'.format(dns_server_1, dns_server_2) + '\n')
+        interfaces_update('#   dns-nameservers ',
+                          '  dns-nameservers {} {}'.format(dns_server_1, dns_server_2) + '\n')
 
 # Ask the user if they would like to restore the backup to the network
 # interfaces file.

--- a/station-update.py
+++ b/station-update.py
@@ -50,7 +50,7 @@ sys.stdout = open('~interfaces_temp', 'w')
 
 for line in fileinput.input('/etc/network/interfaces'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
-    if 'wireless-essid' in line:
+    if 'wireless-essid RPiAdHocNetwork' in line:
         # Create a handle for a new line with the updated station ID to input into the interfaces file.      
         line = '  wireless-essid RPiAdHocNetwork' + ID + '\n'
     

--- a/station-update.py
+++ b/station-update.py
@@ -31,7 +31,7 @@ Part 2: Updating the dosimeter ID on the network configuration file on the Pi-ha
 '''
 
 # Ask for the station ID.
-ID = input('What is the station ID?: ')
+ID = raw_input('What is the station ID?: ')
 
 # Open the interfaces file (and call a file handle for it within the program) and update the network ID.
 with open('/etc/network/interfaces/interfaces', '+') as netConfig:
@@ -40,7 +40,7 @@ with open('/etc/network/interfaces/interfaces', '+') as netConfig:
     # Search for 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
     if 'wireless-essid' in line:
       # Create a handle for a new line with the updated station ID to input into the interfaces file.      
-      line = 'wireless-essid RPiAdHocNetwork' + ID + '\n'
+      line = 'wireless-essid RPiAdHocNetwork' + int(ID) + '\n'
       netConfig.write(line)
 
 

--- a/station-update.py
+++ b/station-update.py
@@ -1,61 +1,32 @@
-'''
+"""
+Network config updater for a DoseNet silicon radiation detector station.
+
 This script securely copies the Pi-hat network configuration file from the
 Dosenet servers to a Pi-hat at a school of interest and updates the network ID
-on the network configuration file for the Pi-hat, as well as handles static
-IPs, netmasks, gateways, and DNS-server names.
-'''
+on the network configuration file for the Pi-hat, as well as handles netmasks,
+gateways, and DNS server names to setup a static IP if necessary. (A dynamic
+IP is set by default.)
+"""
 
-# Import the relevant modules and functions from the appropriate libraries for
-# convenience.
+# Import the relevant modules and functions from the appropriate libraries.
 import fileinput
 import os
 import sys
 
-'''
-Part 1: Securely copying the network configuration file from the Dosenet
-servers to the Pi-hat.
-'''
-
-# Ask the user for the csv file name and output the raw input string as a
-# variable.
-name = raw_input('What is the csv file name?: ')
-
-# Define the paths to the source and target .csv files as arguments for the scp
-# linux command to be executed through the os.sytem function.
-sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + name
-targetPath = '/home/pi/config/config.csv'
-
-# Execute the scp linux command line to securely copy the file over the
-# Internet using root user access.
-os.system('sudo scp {} {}'.format(sourcePath, targetPath))
 
 '''
-Part 2: Updating the dosimeter ID on the network configuration file on the
-Pi-hat once it has been copied securely over the Internet.
-'''
-
-# Backup the interfaces file through the cp linux command to make a backup copy
-# of the interfaces file before any editing is done.
-os.system('sudo cp /etc/network/interfaces /etc/network/interfaces_backup')
-
-# Alert the user that a backup file has been made.
-print('A backup of the network interfaces file has been made. If you make ' +
-      'an error during the rest of the setup, a prompt at the end will ' +
-      'ask if you would like to restore the backup.')
-
-# Ask for the station ID and output the raw input string as a variable.
-id = raw_input('What is the station ID?: ')
-
-'''
-Define a function to update the interfaces file by replacing the line
-containing an indicated phrase with a new line.
+Part 1: Define a function to update the interfaces file by replacing the
+        line containing an indicated phrase with a new line.
 '''
 
 
 def interfaces_update(rep_phrase, new_line):
-    # Store the normal standard input and output. This allows us to restore
-    # them later to access the standard input and output for other uses
-    # outside of this function, such as raw_input and print statements.
+    """Main function to update the network interfaces file."""
+    '''
+    Store the normal standard input and output. This allows us to restore
+    them later to access the standard input and output for other uses
+    outside of this function, such as raw_input and print statements.
+    '''
     temp_in = sys.stdin
     temp_out = sys.stdout
 
@@ -64,10 +35,10 @@ def interfaces_update(rep_phrase, new_line):
     sys.stdin = open('/etc/network/interfaces', 'r')
     sys.stdout = open('~interfaces_temp', 'w')
 
-    """
+    '''
     Loop through each line of the interfaces file to find the phrase of
     interest and replace it with the new line.
-    """
+    '''
 
     for line in fileinput.input('/etc/network/interfaces'):
 
@@ -94,21 +65,99 @@ def interfaces_update(rep_phrase, new_line):
     sys.stdin = temp_in
     sys.stdout = temp_out
 
+'''
+Part 2: Securely copy the network configuration file from the Dosenet
+        servers to the Pi-hat.
+'''
+
+# Ask the user for the csv file name and output the raw input string as a
+# variable.
+name = raw_input('\nWhat is the csv file name?: ')
+
+# Define the paths to the source and target csv files as arguments for the scp
+# linux command to be executed through the os.system function. Note: A
+# password to the DoseNet servers in LBNL will be requested at this point in
+# the script.
+sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + name
+targetPath = '/home/pi/config/config.csv'
+
+# Execute the scp linux command line to securely copy the file over the
+# Internet.
+os.system('scp {} {}'.format(sourcePath, targetPath))
+
+'''
+Part 3: Update the dosimeter ID on the network configuration file on the
+        Pi-hat once it has been copied securely over the Internet.
+'''
+
+# Backup the interfaces file through the cp linux command to make a backup copy
+# of the interfaces file before any editing is done.
+os.system('sudo cp /etc/network/interfaces /etc/network/interfaces_backup')
+
+# Alert the user that a backup file has been made and changes can be kept or
+# reverted later.
+print('\nA backup of the network interfaces file has been made. If you ' +
+      'make an error during the rest of the setup, a prompt at the end ' +
+      'will ask if you would like to keep the changes made and restore the ' +
+      'backup to the interfaces file.')
+
+# Ask for the station ID and output the raw input string as a variable.
+id = raw_input('\nWhat is the station ID?: ')
+
 # Update the station ID using the update function.
 interfaces_update('wireless-essid RPiAdHocNetwork', '  wireless-essid ' +
                   'RPiAdHocNetwork{}'.format(id) + '\n')
 
 # Ask the user if they would like to use a static IP.
-setup_static_ip = raw_input('Do you want to set a static IP (y/n)?: ')
+setup_static_ip = raw_input('\nDo you want to set a static IP (y/n)?: ')
 
-"""
+'''
+If the response is a no, ask additionally if the the user would like to keep
+the changes done to the network interfaces file.
+
 If the response is a yes, update the interfaces file to include the static IP
 and the relevant functionality.
-"""
-if setup_static_ip is 'y':
+'''
+if setup_static_ip.lower() is 'n':
+
+    # Ask the user if they would like to keep the changes to the network
+    # interfaces file.
+    keep_changes = raw_input('\nWould you like to keep these changes ' +
+                             '(y/n)?: ')
+
+    '''
+    If the response is a yes, exit the script and tell the user the network
+    interfaces file has been updated.
+
+    If the response is a no (or anything else), restore the backup to the
+    network interfaces file.
+    '''
+    if keep_changes.lower() is 'y':
+
+        print('\nA dynamic IP has been set. Your Pi-hat sensor module now ' +
+              'has updated network functionality and the appropriate ' +
+              'network interfaces file has been copied over the server.')
+
+    else:
+
+        # Restore the backup interfaces file using the cp linux command
+        # with root access.
+        os.system('sudo cp /etc/network/interfaces_backup ' +
+                  '/etc/network/interfaces')
+
+        # Alert the user that the backup interfaces file has been restored
+        # and to re-run the script if they want to re-setup the network
+        # configuration.
+        print('\nThe network interfaces file has been restored from the ' +
+              'backup and changes have been reverted. Run this Python ' +
+              'script again to setup the network configuration again.')
+
+    sys.exit()
+
+elif setup_static_ip.lower() is 'y':
 
     # Ask for the static IP.
-    ip_static = raw_input('What is your static IP?: ')
+    ip_static = raw_input('\nWhat is your static IP?: ')
 
     # Update the interfaces file with the static IP by commenting out the
     # dynamic IP call and uncommenting out the static IP calls.
@@ -121,16 +170,57 @@ if setup_static_ip is 'y':
     interfaces_update('#   address', '  address {}'.format(ip_static) + '\n')
 
     # Ask the user if they have a netmask.
-    setup_netmask = raw_input('Do you have a netmask (y/n)?: ')
+    setup_netmask = raw_input('\nDo you have a netmask (y/n)?: ')
 
-    """
+    '''
+    If the response is a no, ask additionally if the the user would like to
+    keep the changes done to the network interfaces file.
+
     If the response is a yes, update the interfaces file to include the netmask
     identifier and the relevant functionality.
-    """
-    if setup_netmask is 'y':
+    '''
+    if setup_netmask.lower() is 'n':
+
+        # Ask the user if they would like to keep the changes to the network
+        # interfaces file.
+        keep_changes = raw_input('\nWould you like to keep these changes ' +
+                                 '(y/n)?: ')
+
+        '''
+        If the response is a yes, exit the script and tell the user the network
+        interfaces file has been updated.
+
+        If the response is a no (or anything else), restore the backup to the
+        network interfaces file.
+        '''
+        if keep_changes.lower() is 'y':
+
+            print('\nA static IP has not been set (requires a netmask, ' +
+                  'a gateway, and DNS server names) and a dynamic IP will ' +
+                  'remain. Your Pi-hat sensor module now has updated ' +
+                  'network functionality and the appropriate network ' +
+                  'interfaces file has been copied over the server.')
+
+        else:
+
+            # Restore the backup interfaces file using the cp linux command
+            # with root access.
+            os.system('sudo cp /etc/network/interfaces_backup ' +
+                      '/etc/network/interfaces')
+
+            # Alert the user that the backup interfaces file has been restored
+            # and to re-run the script if they want to re-setup the network
+            # configuration.
+            print('\nThe network interfaces file has been restored from the ' +
+                  'backup and changes have been reverted. Run this Python ' +
+                  'script again to setup the network configuration again.')
+
+        sys.exit()
+
+    elif setup_netmask.lower() is 'y':
 
         # Ask for the netmask identifier.
-        netmask_id = raw_input('What is your netmask identifier?: ')
+        netmask_id = raw_input('\nWhat is your netmask identifier?: ')
 
         # Update the interfaces file with the netmask identifier by
         # uncommenting out the netmask call.
@@ -138,16 +228,57 @@ if setup_static_ip is 'y':
                           '\n')
 
     # Ask the user if they have a gateway.
-    setup_gateway = raw_input('Do you have a gateway (y/n)?: ')
+    setup_gateway = raw_input('\nDo you have a gateway (y/n)?: ')
 
     '''
+    If the response is a no, ask additionally if the the user would like to
+    keep the changes done to the network interfaces file.
+
     If the response is a yes, update the interfaces file to include the gateway
     identifier and the relevant functionality.
     '''
-    if setup_gateway is 'y':
+    if setup_gateway.lower() is 'n':
+
+        # Ask the user if they would like to keep the changes to the network
+        # interfaces file.
+        keep_changes = raw_input('\nWould you like to keep these changes ' +
+                                 '(y/n)?: ')
+
+        '''
+        If the response is a yes, exit the script and tell the user the network
+        interfaces file has been updated.
+
+        If the response is a no (or anything else), restore the backup to the
+        network interfaces file.
+        '''
+        if keep_changes.lower() is 'y':
+
+            print('\nA static IP has not been set (requires a netmask, ' +
+                  'a gateway, and DNS server names) and a dynamic IP will ' +
+                  'remain. Your Pi-hat sensor module now has updated ' +
+                  'network functionality and the appropriate network ' +
+                  'interfaces file has been copied over the server.')
+
+        else:
+
+            # Restore the backup interfaces file using the cp linux command
+            # with root access.
+            os.system('sudo cp /etc/network/interfaces_backup ' +
+                      '/etc/network/interfaces')
+
+            # Alert the user that the backup interfaces file has been restored
+            # and to re-run the script if they want to re-setup the network
+            # configuration.
+            print('\nThe network interfaces file has been restored from the ' +
+                  'backup and changes have been reverted. Run this Python ' +
+                  'script again to setup the network configuration again.')
+
+        sys.exit()
+
+    elif setup_gateway.lower() is 'y':
 
         # Ask for the gateway identifier.
-        gateway_id = raw_input('What is your gateway identifier?: ')
+        gateway_id = raw_input('\nWhat is your gateway identifier?: ')
 
         # Update the interfaces file with the gateway identifier by
         # uncommenting out the gateway call.
@@ -155,38 +286,105 @@ if setup_static_ip is 'y':
                           '\n')
 
     # Ask the user if they have DNS servers connected.
-    setup_dns_server = raw_input('Do you have DNS servers connected (y/n)?: ')
+    setup_dns_server = raw_input('\nDo you have DNS servers connected ' +
+                                 '(y/n)?: ')
 
     '''
+    If the response is a no, ask additionally if the the user would like to
+    keep the changes done to the network interfaces file.
+
     If the response is a yes, update the interfaces file to include the DNS
     server names and the relevant functionality.
     '''
-    if setup_dns_server is 'y':
+    if setup_dns_server.lower() is 'n':
+
+        # Ask the user if they would like to keep the changes to the network
+        # interfaces file.
+        keep_changes = raw_input('\nWould you like to keep these changes ' +
+                                 '(y/n)?: ')
+
+        '''
+        If the response is a yes, exit the script and tell the user the network
+        interfaces file has been updated.
+
+        If the response is a no (or anything else), restore the backup to the
+        network interfaces file.
+        '''
+        if keep_changes.lower() is 'y':
+
+            print('\nA static IP has not been set (requires a netmask, ' +
+                  'a gateway, and DNS server names) and a dynamic IP will ' +
+                  'remain. Your Pi-hat sensor module now has updated ' +
+                  'network functionality and the appropriate network ' +
+                  'interfaces file has been copied over the server.')
+
+        else:
+
+            # Restore the backup interfaces file using the cp linux command
+            # with root access.
+            os.system('sudo cp /etc/network/interfaces_backup ' +
+                      '/etc/network/interfaces')
+
+            # Alert the user that the backup interfaces file has been restored
+            # and to re-run the script if they want to re-setup the network
+            # configuration.
+            print('\nThe network interfaces file has been restored from the ' +
+                  'backup and changes have been reverted. Run this Python ' +
+                  'script again to setup the network configuration again.')
+
+        sys.exit()
+
+    elif setup_dns_server.lower() is 'y':
 
         # Ask for the DNS server names.
-        dns_server_1 = raw_input('What is the IP of the first DNS server?: ')
-        dns_server_2 = raw_input('What is the IP of the second DNS server?: ')
+        dns_server_1 = raw_input('\nWhat is the IP of the first DNS ' +
+                                 'server?: ')
+        dns_server_2 = raw_input('\nWhat is the IP of the second DNS ' +
+                                 'server?: ')
 
         # Update the interfaces file with the DNS server names by uncommenting
         # out the DNS server names call.
         interfaces_update("#   dns-nameservers", "  dns-nameservers " +
                           "{} {}".format(dns_server_1, dns_server_2) + '\n')
 
-# Ask the user if they would like to restore the backup to the network
+else:
+
+    sys.exit()
+
+'''
+Part 4: Perform a final check on whether the user wants to keep the changes
+        to the interfaces file and output the results of the configuration of
+        a static IP if the script has not been exited at this point.
+'''
+
+# Ask the user if they would like to keep the changes to the network
 # interfaces file.
-restore_backup = raw_input('Would you like to restore the backup of the ' +
-                           'network interfaces update (y/n)?: ')
+keep_changes = raw_input('\nWould you like to keep these changes (y/n)?: ')
 
-# If the response is a yes, copy the backup over the original file that has
-# been modified.
-if restore_backup is 'y':
+'''
+If the response is a yes, exit the script and tell the user the network
+interfaces file has been updated.
 
-    # Restore the backup interfaces file using the cp linux command with root
-    # access.
-    os.system('sudo cp /etc/network/interfaces_backup /etc/network/interfaces')
+If the response is a no (or anything else), restore the backup to the
+network interfaces file.
+'''
+if keep_changes.lower() is 'y':
 
-    # Alert the user that the backup interfaces file has been restored and to
-    # rerun the script if they want to re-setup the network configuration.
-    print('The network interfaces file has been restored from the backup. ' +
-          'Run this Python script again to setup the network ' +
-          'configuration again.')
+    print('\nA static IP has been set with your indicated netmask, gateway, ' +
+          'and DNS server name identifiers. Your Pi-hat sensor module now ' +
+          'has updated network functionality and the appropriate network ' +
+          'interfaces file has been copied over the server.')
+
+else:
+
+    # Restore the backup interfaces file using the cp linux command
+    # with root access.
+    os.system('sudo cp /etc/network/interfaces_backup ' +
+              '/etc/network/interfaces')
+
+    # Alert the user that the backup interfaces file has been restored
+    # and to re-run the script if they want to re-setup the network
+    # configuration.
+    print('\nThe network interfaces file has been restored from the ' +
+          'backup and changes have been reverted. Run this Python ' +
+          'script again to setup the network configuration again.')

--- a/station-update.py
+++ b/station-update.py
@@ -65,6 +65,6 @@ with open('interfaces', '+', opener=opendir) as netConfig:
       line = 'wireless-essid RPiAdHocNetwork' + ID + '\n'
       netConfig.write(line)
 
-# Close the file directory
+# Close the file directory.
 os.close(dirConfig)
 '''

--- a/station-update.py
+++ b/station-update.py
@@ -1,182 +1,192 @@
-# Author: Yaro Kaminskiy
-
 '''
-This script securely copies the Pi-hat network configuration file from the Dosenet servers to a Pi-hat at a school of interest and
-updates the network ID on the network configuration file for the Pi-hat, as well as handles static IPs, netmasks, gateways, and
-DNS-server names.
+This script securely copies the Pi-hat network configuration file from the
+Dosenet servers to a Pi-hat at a school of interest and updates the network ID
+on the network configuration file for the Pi-hat, as well as handles static
+IPs, netmasks, gateways, and DNS-server names.
 '''
 
-# Import the relevant modules and functions from the appropriate libraries for convenience.
+# Import the relevant modules and functions from the appropriate libraries for
+# convenience.
 import fileinput
-import sys
 import os
-from tempfile import mkstemp
+import sys
 
 '''
-Part 1: Securely copying the network configuration file from the Dosenet servers to the Pi-hat.
+Part 1: Securely copying the network configuration file from the Dosenet
+servers to the Pi-hat.
 '''
 
-# Ask the user for the csv file name and output the raw input string as a variable.
-NAME = raw_input('What is the csv file name?: ')
+# Ask the user for the csv file name and output the raw input string as a
+# variable.
+name = raw_input('What is the csv file name?: ')
 
-# Define the paths to the source and target .csv files as arguments for the scp linux command to be executed through the os.sytem function.
-sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
+# Define the paths to the source and target .csv files as arguments for the scp
+# linux command to be executed through the os.sytem function.
+sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + name
 targetPath = '/home/pi/config/config.csv'
 
-# Execute the scp linux command line to securely copy the file over the Internet using root user access.
-os.system('sudo scp "%s" "%s"' % (sourcePath, targetPath))
+# Execute the scp linux command line to securely copy the file over the
+# Internet using root user access.
+os.system('sudo scp {} {}'.format(sourcePath, targetPath))
 
 '''
-Part 2: Updating the dosimeter ID on the network configuration file on the Pi-hat once it has been copied securely over the Internet.
+Part 2: Updating the dosimeter ID on the network configuration file on the
+Pi-hat once it has been copied securely over the Internet.
 '''
 
-# Backup the interfaces file through the cp linux command to make a backup copy of the interfaces file before any editting is done.
+# Backup the interfaces file through the cp linux command to make a backup copy
+# of the interfaces file before any editing is done.
 os.system('sudo cp /etc/network/interfaces /etc/network/interfaces_backup')
 
 # Alert the user that a backup file has been made.
-print 'A backup of the network interfaces file has been made. If you make an error during the rest of the setup, a prompt at the end will ask if you would like to restore the backup.'
+print('A backup of the network interfaces file has been made. If you make ' +
+      'an error during the rest of the setup, a prompt at the end will ' +
+      'ask if you would like to restore the backup.')
 
 # Ask for the station ID and output the raw input string as a variable.
-ID = raw_input('What is the station ID?: ')
+id = raw_input('What is the station ID?: ')
 
 '''
-Define a function to update the interfaces file by replacing the line containing an indicated phrase with a new line.
+Define a function to update the interfaces file by replacing the line
+containing an indicated phrase with a new line.
 '''
 
-def interfacesUpdate(repPhrase, newLine):
-	'''
-	# METHOD 1
-	tempFile, tempPath = mkstemp()
-	
-	with open(tempPath, 'w') as tempInterfaces:
-		with open('/etc/network/interfaces', 'r') as oldInterfaces:
-			for line in oldInterfaces:
-				tempInterfaces.write(line.replace(repPhrase, newLine))
-				
-	os.close(tempFile)
-	
-    	# Move the updated interfaces file to replace the old interfaces file using root access.
-	os.system('sudo mv %s /etc/network/interfaces' % tempPath)
-	'''
-	
-	# METHOD 2
-	
-	# Store the original standard input and output.
-	tempIn = sys.stdin
-	tempOut = sys.stdout
 
-	# Open the interfaces file for reading and open up a temporary file for writing using the standard input and output functions.
-	sys.stdin = open('/etc/network/interfaces', 'r')
-	sys.stdout = open('~interfaces_temp', 'w')
-	
-	'''
-	Loop through each line of the interfaces file to find the phrase of interest and replace it with the new line.
-	'''
-	
-	for line in fileinput.input('/etc/network/interfaces'):
+def interfaces_update(rep_phrase, new_line):
+    # Store the normal standard input and output. This allows us to restore
+    # them later to access the standard input and output for other uses
+    # outside of this function, such as raw_input and print statements.
+    temp_in = sys.stdin
+    temp_out = sys.stdout
 
-		# Search and find the phrase of interest to indicate the place in the code to replace the original line with
-    		# the new line.
-    		if repPhrase in line:
+    # Open the interfaces file for reading and open up a temporary file for
+    # writing using the standard input and output functions.
+    sys.stdin = open('/etc/network/interfaces', 'r')
+    sys.stdout = open('~interfaces_temp', 'w')
 
-    	    		# Create a handle for a new line with the updated phrase to input into the interfaces file.      
-    	    		line = newLine
-    
-    		# Write the new line with the updated station ID in the temporary interfaces file. Also copy all other lines.
-    		sys.stdout.write(line)
+    """
+    Loop through each line of the interfaces file to find the phrase of
+    interest and replace it with the new line.
+    """
 
-    	# Move the updated interfaces file to replace the old interfaces file using root access.
-	os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
+    for line in fileinput.input('/etc/network/interfaces'):
 
-	# Close the interfaces files for reading and writing
-	sys.stdout.close()
+        # Search and find the phrase of interest to indicate the place in the
+        # code to replace the original line with the new line.
+        if rep_phrase in line:
 
-	# Return the original standard input and output.
-	sys.stdin = tempIn
-	sys.stdout = tempOut
+            # Create a handle for a new line with the updated phrase to input
+            # into the interfaces file.
+            line = new_line
 
-# Update the station using the update function.
-interfacesUpdate('wireless-essid RPiAdHocNetwork', '  wireless-essid RPiAdHocNetwork%s' % ID + '\n')
+        # Write the new line with the updated phrase in the temporary
+        # interfaces file. Also copy all other lines.
+        sys.stdout.write(line)
+
+    # Move the updated interfaces file to replace the old interfaces file
+    # using root access.
+    os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
+
+    # Close the interfaces files for reading and writing
+    sys.stdout.close()
+
+    # Return the original standard input and output to normal.
+    sys.stdin = temp_in
+    sys.stdout = temp_out
+
+# Update the station ID using the update function.
+interfaces_update('wireless-essid RPiAdHocNetwork', '  wireless-essid ' +
+                  'RPiAdHocNetwork{}'.format(id) + '\n')
 
 # Ask the user if they would like to use a static IP.
-setupStaticIP = raw_input('Do you want to set a static IP (y/n)?: ')
-	
-print setupStaticIP
+setup_static_ip = raw_input('Do you want to set a static IP (y/n)?: ')
 
-'''
-If the response is a yes, update the interfaces file to include the static IP and the relevant functionality.
-'''
-if setupStaticIP is 'y':
-	
-	print setupStaticIP
+"""
+If the response is a yes, update the interfaces file to include the static IP
+and the relevant functionality.
+"""
+if setup_static_ip is 'y':
 
-	# Ask for the static IP.
-	IP_static = raw_input('What is your static IP?: ')
+    # Ask for the static IP.
+    ip_static = raw_input('What is your static IP?: ')
 
-	# Update the interfaces file with the static IP by commenting out the dynamic IP call and
-	# uncommenting out the static IP calls. 
-	interfacesUpdate('iface eth0 inet dhcp', '# replace for dynamic IP configuration\n# iface eth0 inet dhcp' + '\n')
-	interfacesUpdate('# auto eth0', 'auto eth0' + '\n')
-	interfacesUpdate('# iface eth0 inet static', 'iface eth0 inet static' + '\n')
-	interfacesUpdate('#   address', '  address %s' % IP_static + '\n')
+    # Update the interfaces file with the static IP by commenting out the
+    # dynamic IP call and uncommenting out the static IP calls.
+    interfaces_update('iface eth0 inet dhcp', '# replace for dynamic IP ' +
+                      'configuration' + '\n' + '# iface eth0 inet dhcp' +
+                      '\n')
+    interfaces_update('# auto eth0', 'auto eth0' + '\n')
+    interfaces_update('# iface eth0 inet static', 'iface eth0 inet static' +
+                      '\n')
+    interfaces_update('#   address', '  address {}'.format(ip_static) + '\n')
 
-	# Ask the user if they have a netmask.
-	setupNetmask = raw_input('Do you have a netmask (y/n)?: ')
+    # Ask the user if they have a netmask.
+    setup_netmask = raw_input('Do you have a netmask (y/n)?: ')
 
-	'''
-	If the response is a yes, update the interfaces file to include the netmask identifier and the
-	relevant functionality.
-	'''
-	if setupNetmask is 'y':
+    """
+    If the response is a yes, update the interfaces file to include the netmask
+    identifier and the relevant functionality.
+    """
+    if setup_netmask is 'y':
 
-		# Ask for the netmask identifier.
-		netmask_ID = raw_input('What is your netmask identifier?: ')
+        # Ask for the netmask identifier.
+        netmask_id = raw_input('What is your netmask identifier?: ')
 
-		# Update the interfaces file with the netmask identifier by uncommenting out the netmask
-		# call.
-		interfacesUpdate('#   netmask', '  netmask %s' % netmask_ID + '\n')
+        # Update the interfaces file with the netmask identifier by
+        # uncommenting out the netmask call.
+        interfaces_update('#   netmask', '  netmask {}'.format(netmask_id) +
+                          '\n')
 
-	# Ask the user if they have a gateway.
-	setupGateway = raw_input('Do you have a gateway (y/n)?: ')
+    # Ask the user if they have a gateway.
+    setup_gateway = raw_input('Do you have a gateway (y/n)?: ')
 
-	'''
-	If the response is a yes, update the interfaces file to include the gateway identifier and the
-	relevant functionality.
-	'''
-	if setupGateway is 'y':
+    '''
+    If the response is a yes, update the interfaces file to include the gateway
+    identifier and the relevant functionality.
+    '''
+    if setup_gateway is 'y':
 
-		# Ask for the gateway identifier.
-		gateway_ID = raw_input('What is your gateway identifier?: ')
+        # Ask for the gateway identifier.
+        gateway_id = raw_input('What is your gateway identifier?: ')
 
-		# Update the interfaces file with the gateway identifier by uncommenting out the gateway
-		# call.
-		interfacesUpdate('#   gateway', '  gateway %s' % gateway_ID + '\n')
+        # Update the interfaces file with the gateway identifier by
+        # uncommenting out the gateway call.
+        interfaces_update('#   gateway', '  gateway {}'.format(gateway_id) +
+                          '\n')
 
-	# Ask the user if they have DNS servers connected.
-	setupDNSserver = raw_input('Do you have DNS servers connected (y/n)?: ')
+    # Ask the user if they have DNS servers connected.
+    setup_dns_server = raw_input('Do you have DNS servers connected (y/n)?: ')
 
-	'''
-	If the response is a yes, update the interfaces file to include the DNS server names and the
-	relevant functionality.
-	'''
-	if setupDNSserver is 'y':
+    '''
+    If the response is a yes, update the interfaces file to include the DNS
+    server names and the relevant functionality.
+    '''
+    if setup_dns_server is 'y':
 
-		# Ask for the DNS server names.
-		name1 = raw_input('What is the IP of the first DNS server?: ')
-		name2 = raw_input('What is the IP of the second DNS server?: ')
+        # Ask for the DNS server names.
+        dns_server_1 = raw_input('What is the IP of the first DNS server?: ')
+        dns_server_2 = raw_input('What is the IP of the second DNS server?: ')
 
-		# Update the interfaces file with the DNS server names by uncommenting out the DNS server
-		# names call.
-		interfacesUpdate('#   dns-nameservers ', '  dns-nameservers "%s" "%s"' % (name1, name2) + '\n')
+        # Update the interfaces file with the DNS server names by uncommenting
+        # out the DNS server names call.
+        interfaces_update('#   dns-nameservers ', '  dns-nameservers ' +
+                          '{} {}'.format(dns_server_1, dns_server_2) + '\n')
 
-# Ask the user if they would like to restore the backup to the network interfaces file.
-restoreBackup = raw_input('Would you like to restore the backup of the network interfaces update (y/n)?: ')
+# Ask the user if they would like to restore the backup to the network
+# interfaces file.
+restore_backup = raw_input('Would you like to restore the backup of the ' +
+                           'network interfaces update (y/n)?: ')
 
-# If the response is a yes, copy the backup over the original file that has been modified.
-if restoreBackup is 'y':
+# If the response is a yes, copy the backup over the original file that has
+# been modified.
+if restore_backup is 'y':
 
-	# Restore the backup interfaces file using the cp linux command with root access.
-	os.system('sudo cp /etc/network/interfaces_backup /etc/network/interfaces')
+    # Restore the backup interfaces file using the cp linux command with root
+    # access.
+    os.system('sudo cp /etc/network/interfaces_backup /etc/network/interfaces')
 
-	# Alert the user that the backup interfaces file has been restored and to rerun the script if they want to re-setup the network configuration.
-	print 'The network interfaces file has been restored from the backup. Run this python script again to setup the network configuration again.'
+    # Alert the user that the backup interfaces file has been restored and to
+    # rerun the script if they want to re-setup the network configuration.
+    print('The network interfaces file has been restored from the backup. ' +
+          'Run this Python script again to setup the network ' +
+          'configuration again.')

--- a/station-update.py
+++ b/station-update.py
@@ -44,7 +44,7 @@ by the user.
 
 # Open the interfaces file for writing using the print statement and write to a temporary file.
 sys.stdin = open('/etc/network/interfaces', 'r')
-sys.stdout = open('~/interfaces_temp', 'w')
+sys.stdout = open('~interfaces_temp', 'w')
 
 for line in fileinput.input('/etc/network/interfaces'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
@@ -55,7 +55,7 @@ for line in fileinput.input('/etc/network/interfaces'):
     # Write the new line with the updated station ID in the interfaces file.
     sys.stdout.write(line)
 
-l = os.system('sudo mv ~/interfaces_temp /etc/network/interfaces')
+l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
 
 # Print the scp linux command that was executed for debugging purposes.
 print 'FOR DEBUGGING, linux command: %s' % l

--- a/station-update.py
+++ b/station-update.py
@@ -16,6 +16,9 @@ NAME = input("What is the csv file name?:")
 
 print 'csv file name: ', NAME
 
+args = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/', NAME, '/home/pi/config/config.csv'
+print args
+
 # Execute the linux command line and wait until it executes for the script to continue.
 p = Popen("scp", "dosenet@dosenet.dhcp.lbl.gov:~/config-files/", str(NAME), "/home/pi/config/config.csv").wait()
 

--- a/station-update.py
+++ b/station-update.py
@@ -52,12 +52,12 @@ for line in fileinput.input('/etc/network/interfaces'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
     if 'wireless-essid' in line:
         # Create a handle for a new line with the updated station ID to input into the interfaces file.      
-        line = '  wireless-essid RPiAdHocNetwork' + ID
+        line = '  wireless-essid RPiAdHocNetwork' + ID + /n
     
     # Write the new line with the updated station ID in the interfaces file.
-    print(line)
+    sys.stdout.write(line)
 
-l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces_test')
+l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
 
 sys.stdout.close()
 

--- a/station-update.py
+++ b/station-update.py
@@ -161,3 +161,6 @@ if restoreBackup == 'Y' or 'y':
 
 	# Alert the user that the backup interfaces file has been restored and to rerun the script if they want to re-setup the network configuration.
 	print 'The network interfaces file has been restored from the backup. Run this python script again to setup the network configuration again.'
+
+	
+	#

--- a/station-update.py
+++ b/station-update.py
@@ -12,13 +12,13 @@ import os
 from subprocess import Popen
 
 # Ask the user for the csv file name.
-NAME = input('What is the csv file name?: ')
+NAME = raw_input('What is the csv file name?: ')
 
 # Print the csv file name inputed by the user for debugging purposes.
 print 'FOR DEGUBBING, csv file name: %s' % NAME
 
 # Define the paths to the source and target .csv files as arguments for the scp linux command to be executed through the Popen function.
-sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + str(NAME)
+sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
 targetPath = '/home/pi/config/config.csv'
 
 # Execute the linux command line to securely copy the file over the Internet. Wait until it executes for this Python script to continue.

--- a/station-update.py
+++ b/station-update.py
@@ -16,7 +16,7 @@ NAME = input("What is the csv file name?:")
 
 print 'csv file name: ', NAME
 
-args = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/', NAME, '/home/pi/config/config.csv'
+args = 'scp dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME + ' /home/pi/config/config.csv'
 print args
 
 # Execute the linux command line and wait until it executes for the script to continue.

--- a/station-update.py
+++ b/station-update.py
@@ -71,9 +71,6 @@ def interfacesUpdate(repPhrase, newLine):
 	# Return the original standard output.
 	sys.stdout = temp
 
-	# Exit the function.
-	return
-
 # Ask for the station ID and output the raw input string as a variable.
 ID = raw_input('What is the station ID?: ')
 

--- a/station-update.py
+++ b/station-update.py
@@ -41,7 +41,7 @@ ID = raw_input('What is the station ID?: ')
 Loop through each line of the interfaces file to find the default station ID placeholder and replace it with the station ID provided
 by the user.
 '''
-for line in fileinput.input('/etc/network/interfaces', inplace=1):
+for line in fileinput.input('/etc/network/interfaces', inplace=1, backup='.bak'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
     if 'wireless-essid' in line:
         # Create a handle for a new line with the updated station ID to input into the interfaces file.      

--- a/station-update.py
+++ b/station-update.py
@@ -14,8 +14,12 @@ from subprocess import Popen
 # Ask the user for the csv file name.
 NAME = input("What is the csv file name?:")
 
+print (NAME,"csv file name")
+
 # Execute the linux command line and wait until it executes for the script to continue.
 p = Popen("scp", "dosenet@dosenet.dhcp.lbl.gov:~/config-files/", NAME, "/home/pi/config/config.csv").wait()
+
+print (p, "linux command")
 
 # Ask for the station ID.
 ID = input("What is the station ID?:")

--- a/station-update.py
+++ b/station-update.py
@@ -11,6 +11,10 @@ import fileinput
 import sys
 import os
 
+from tempfile import mkstemp
+from shutil import move
+from os import remove, close
+
 '''
 Part 1: Securely copying the network configuration file from the Dosenet servers to the Pi-hat.
 '''
@@ -41,7 +45,21 @@ ID = raw_input('What is the station ID?: ')
 '''
 Define a function to update the interfaces file by replacing the line containing an indicated phrase with a new line.
 '''
+
 def interfacesUpdate(repPhrase, newLine):
+	tempFile, tempPath = mkstemp()
+	
+	with open(tempPath, 'w') as tempInterfaces:
+		with open('/etc/network/interfaces', 'w') as oldInterfaces:
+			for line in oldInterfaces:
+				tempInterfaces.write(line.replace(repPhrase, newLine))
+				
+	close(tempFile)
+	
+    	# Move the updated interfaces file to replace the old interfaces file using root access.
+	os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
+				
+	'''
 
 	# Store the original standard output.
 	temp = sys.stdout
@@ -51,7 +69,9 @@ def interfacesUpdate(repPhrase, newLine):
 	sys.stdout = open('~interfaces_temp', 'w')
 
 	'''
+	'''
 	Loop through each line of the interfaces file to find the phrase of interest and replace it with the new line.
+	'''
 	'''
 	for line in fileinput.input('/etc/network/interfaces'):
 
@@ -73,6 +93,8 @@ def interfacesUpdate(repPhrase, newLine):
 
 	# Return the original standard output.
 	sys.stdout = temp
+	
+	'''
 
 # Update the station using the update function.
 interfacesUpdate('wireless-essid RPiAdHocNetwork', '  wireless-essid RPiAdHocNetwork%s' % ID + '\n')

--- a/station-update.py
+++ b/station-update.py
@@ -17,11 +17,11 @@ NAME = raw_input('What is the csv file name?: ')
 print 'FOR DEGUBBING, csv file name: %s' % NAME
 
 # Define the paths to the source and target .csv files as arguments for the scp linux command to be executed through the Popen function.
-sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
-targetPath = '/home/pi/config/config.csv'
+sourcePath = ' dosenet@dosenet.dhcp.lbl.gov:~/config-files/ ' + NAME
+targetPath = ' /home/pi/config/config.csv'
 
 # Execute the linux command line to securely copy the file over the Internet. Wait until it executes for this Python script to continue.
-p = os.system(['scp' + sourcePath + targetPath]).wait()
+p = os.system('scp' + sourcePath + targetPath).wait()
 
 # Print the scp linux command that was executed for debugging purposes.
 print 'FOR DEBUGGING, linux command: ', p

--- a/station-update.py
+++ b/station-update.py
@@ -57,5 +57,7 @@ for line in fileinput.input('/etc/network/interfaces'):
 
 l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
 
+sys.stdout.close()
+
 # Print the scp linux command that was executed for debugging purposes.
 print 'FOR DEBUGGING, linux command: %s' % l

--- a/station-update.py
+++ b/station-update.py
@@ -44,7 +44,7 @@ by the user.
 
 # Open the interfaces file for writing using the print statement and write to a temporary file.
 sys.stdin = open('/etc/network/interfaces', 'r')
-sys.stdout = open('/devel/dosenet-raspberrypi/interfaces_temp', 'w')
+sys.stdout = open('~/interfaces_temp', 'w')
 
 for line in fileinput.input('/etc/network/interfaces'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
@@ -55,7 +55,7 @@ for line in fileinput.input('/etc/network/interfaces'):
     # Write the new line with the updated station ID in the interfaces file.
     sys.stdout.write(line)
 
-l = os.system('sudo mv /devel/dosenet-raspberrypi/interfaces_temp /etc/network/interfaces')
+l = os.system('sudo mv ~/interfaces_temp /etc/network/interfaces')
 
 # Print the scp linux command that was executed for debugging purposes.
 print 'FOR DEBUGGING, linux command: %s' % l

--- a/station-update.py
+++ b/station-update.py
@@ -20,7 +20,7 @@ args = 'scp dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME + ' /home/pi/co
 print args
 
 # Execute the linux command line and wait until it executes for the script to continue.
-p = Popen("scp", "dosenet@dosenet.dhcp.lbl.gov:~/config-files/", str(NAME), "/home/pi/config/config.csv").wait()
+p = Popen(args).wait()
 
 print ("linux command: ", p)
 

--- a/station-update.py
+++ b/station-update.py
@@ -52,7 +52,7 @@ for line in fileinput.input('/etc/network/interfaces'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
     if 'wireless-essid' in line:
         # Create a handle for a new line with the updated station ID to input into the interfaces file.      
-        line = '  wireless-essid RPiAdHocNetwork' + ID + /n
+        line = '  wireless-essid RPiAdHocNetwork' + ID + '/n'
     
     # Write the new line with the updated station ID in the interfaces file.
     sys.stdout.write(line)

--- a/station-update.py
+++ b/station-update.py
@@ -63,16 +63,13 @@ def interfacesUpdate(repPhrase, newLine):
     		sys.stdout.write(line)
 
     	# Move the updated interfaces file to replace the old interfaces file using root access.
-	l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
+	os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
 
 	# Close the interfaces files for reading and writing
 	sys.stdout.close()
 
 	# Return the original standard output.
 	sys.stdout = temp
-
-	# Print the scp linux command that was executed for debugging purposes.
-	print 'FOR DEBUGGING, linux command: %s' % l
 
 	# Exit the function.
 	return

--- a/station-update.py
+++ b/station-update.py
@@ -2,7 +2,8 @@
 
 '''
 This script securely copies the Pi-hat network configuration file from the Dosenet servers to a Pi-hat at a school of interest and
-updates the network ID on the network configuration file for the Pi-hat.
+updates the network ID on the network configuration file for the Pi-hat, as well as handles static IPs, netmasks, gateways, and
+DNS-server names.
 '''
 
 # Import the relevant modules and functions from the appropriate libraries for convenience.
@@ -17,51 +18,146 @@ Part 1: Securely copying the network configuration file from the Dosenet servers
 # Ask the user for the csv file name and output the raw input string as a variable.
 NAME = raw_input('What is the csv file name?: ')
 
-# Print the csv file name inputed by the user for debugging purposes.
-print 'FOR DEGUBBING, csv file name: %s' % NAME
-
 # Define the paths to the source and target .csv files as arguments for the scp linux command to be executed through the os.sytem function.
 sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
 targetPath = '/home/pi/config/config.csv'
 
-# Execute the linux command line to securely copy the file over the Internet.
-p = os.system('sudo scp "%s" "%s"' % (sourcePath, targetPath))
-
-# Print the scp linux command that was executed for debugging purposes.
-print 'FOR DEBUGGING, linux command: %s' % p
+# Execute the scp linux command line to securely copy the file over the Internet using root user access.
+os.system('sudo scp "%s" "%s"' % (sourcePath, targetPath))
 
 '''
 Part 2: Updating the dosimeter ID on the network configuration file on the Pi-hat once it has been copied securely over the Internet.
 '''
 
+# Backup the interfaces file through the cp linux command to make a backup copy of the interfaces file before any editting is done.
+os.system('sudo cp /etc/network/interfaces /etc/network/interfaces_backup')
+
+# Alert the user that a backup file has been made.
+print "A backup of the network interfaces file has been made. If you make an error during the rest of the setup, a prompt at the end will ask if you'd like to restore the backup."
+
+'''
+Define a function to update the interfaces file by replacing the line containing an indicated phrase with a new line.
+'''
+def interfacesUpdate(repPhrase, newLine):
+
+	# Store the original standard output.
+	temp = sys.stdout
+
+	# Open the interfaces file for reading and open up a temporary file for writing using the standard input and output functions.
+	sys.stdin = open('/etc/network/interfaces', 'r')
+	sys.stdout = open('~interfaces_temp', 'w')
+
+	'''
+	Loop through each line of the interfaces file to find the phrase of interest and replace it with the new line.
+	'''
+	for line in fileinput.input('/etc/network/interfaces'):
+
+		# Search and find the phrase of interest to indicate the place in the code to replace the original line with
+    	# the new line.
+    	if repPhrase in line:
+
+    	    # Create a handle for a new line with the updated phrase to input into the interfaces file.      
+    	    line = newLine
+    
+    	# Write the new line with the updated station ID in the temporary interfaces file.
+    	sys.stdout.write(line)
+
+    # Move the updated interfaces file to replace the old interfaces file using root access.
+	l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
+
+	# Close the interfaces files for reading and writing
+	sys.stdout.close()
+
+	# Return the original standard output.
+	sys.stdout = temp
+
+	# Print the scp linux command that was executed for debugging purposes.
+	print 'FOR DEBUGGING, linux command: %s' % l
+
+	# Exit the function.
+	return
+
 # Ask for the station ID and output the raw input string as a variable.
 ID = raw_input('What is the station ID?: ')
 
+# Update the station using the update function.
+interfacesUpdate('wireless-essid RPiAdHocNetwork', '  wireless-essid RPiAdHocNetwork%s' % ID + '\n')
+
+# Ask the user if they would like to use a static IP.
+setupStaticIP = raw_input('Do you want to set a static IP (Y/N)?: ')
+
 '''
-Loop through each line of the interfaces file to find the default station ID placeholder and replace it with the station ID provided
-by the user.
+If the response is a yes, update the interfaces file to include the static IP and the relevant functionality.
 '''
+if setupStaticIP == 'Y' or 'y':
 
-temp = sys.stdout
+	# Ask for the static IP.
+	IP_static = raw_input('What is your static IP?: ')
 
-# Open the interfaces file for writing using the print statement and write to a temporary file.
-sys.stdin = open('/etc/network/interfaces', 'r')
-sys.stdout = open('~interfaces_temp', 'w')
+	# Update the interfaces file with the static IP by commenting out the dynamic IP call and
+	# uncommenting out the static IP calls. 
+	interfacesUpdate('iface eth0 inet dhcp', '# replace for dynamic IP configuration\n# iface eth0 inet dhcp')
+	interfacesUpdate('# auto eth0', 'auto eth0')
+	interfacesUpdate('# iface eth0 inet static', 'iface eth0 inet static')
+	interfacesUpdate('#   address', '  address %s' % IP_static)
 
-for line in fileinput.input('/etc/network/interfaces'):
-    # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
-    if 'wireless-essid RPiAdHocNetwork' in line:
-        # Create a handle for a new line with the updated station ID to input into the interfaces file.      
-        line = '  wireless-essid RPiAdHocNetwork' + ID + '\n'
-    
-    # Write the new line with the updated station ID in the interfaces file.
-    sys.stdout.write(line)
+	# Ask the user if they have a netmask.
+	setupNetmask = raw_input('Do you have a netmask (Y/N)?: ')
 
-l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
+	'''
+	If the response is a yes, update the interfaces file to include the netmask identifier and the
+	relevant functionality.
+	'''
+	if setupNetmask == 'Y' or 'y':
 
-sys.stdout.close()
+		# Ask for the netmask identifier.
+		netmask_ID = raw_input('What is your netmask identifier?: ')
 
-sys.stdout = temp
+		# Update the interfaces file with the netmask identifier by uncommenting out the netmask
+		# call.
+		interfacesUpdate('#   netmask', '  netmask %s' % netmask_ID)
 
-# Print the scp linux command that was executed for debugging purposes.
-print 'FOR DEBUGGING, linux command: %s' % l
+	# Ask the user if they have a gateway.
+	setupGateway = raw_input('Do you have a gateway (Y/N)?: ')
+
+	'''
+	If the response is a yes, update the interfaces file to include the gateway identifier and the
+	relevant functionality.
+	'''
+	if setupGateway == 'Y' or 'y':
+
+		# Ask for the gateway identifier.
+		gateway_ID = raw_input('What is your gateway identifier?: ')
+
+		# Update the interfaces file with the gateway identifier by uncommenting out the gateway
+		# call.
+		interfacesUpdate('#   gateway', '  gateway %s' % gateway_ID)
+
+	# Ask the user if they have DNS servers connected.
+	setupDNSserver = raw_input('Do you have DNS servers connected (Y/N)?: ')
+
+	'''
+	If the response is a yes, update the interfaces file to include the DNS server names and the
+	relevant functionality.
+	'''
+	if setupDNSserver == 'Y' or 'y':
+
+		# Ask for the DNS server names.
+		name1 = raw_input('What is the IP of the first DNS server?: ')
+		name2 = raw_input('What is the IP of the second DNS server?: ')
+
+		# Update the interfaces file with the DNS server names by uncommenting out the DNS server
+		# names call.
+		interfacesUpdate('#   dns-nameservers ', '  dns-nameservers "%s" "%s"' % (name1, name2))
+
+# Ask the user if they would like to restore the backup to the network interfaces file.
+restoreBackup = raw_input('Would you like to restore the backup of the network interfaces update (Y/N)?: ')
+
+# If the response is a yes, copy the backup over the original file that has been modified.
+if restoreBackup == 'Y' or 'y':
+
+	# Restore the backup interfaces file using the cp linux command with root access.
+	os.system('sudo cp /etc/network/interfaces_backup /etc/network/interfaces')
+
+	# Alert the user that the backup interfaces file has been restored and to rerun the script if they want to re-setup the network configuration.
+	print 'The network interfaces file has been restored from the backup. Run this python script again to setup the network configuration again.'

--- a/station-update.py
+++ b/station-update.py
@@ -40,7 +40,7 @@ with open('/etc/network/interfaces', 'r+') as netConfig:
     # Search for 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
     if 'wireless-essid' in line:
       # Create a handle for a new line with the updated station ID to input into the interfaces file.      
-      line = 'wireless-essid RPiAdHocNetwork' + int(ID) + '\n'
+      line = 'wireless-essid RPiAdHocNetwork' + ID + '\n'
       netConfig.write(line)
 
 

--- a/station-update.py
+++ b/station-update.py
@@ -86,7 +86,7 @@ setupStaticIP = raw_input('Do you want to set a static IP (Y/N)?: ')
 '''
 If the response is a yes, update the interfaces file to include the static IP and the relevant functionality.
 '''
-if setupStaticIP == 'Y' or 'y':
+if setupStaticIP == 'Y' or setupStaticIP == 'y':
 
 	# Ask for the static IP.
 	IP_static = raw_input('What is your static IP?: ')
@@ -105,7 +105,7 @@ if setupStaticIP == 'Y' or 'y':
 	If the response is a yes, update the interfaces file to include the netmask identifier and the
 	relevant functionality.
 	'''
-	if setupNetmask == 'Y' or 'y':
+	if setupNetmask == 'Y' or setupNetmask == 'y':
 
 		# Ask for the netmask identifier.
 		netmask_ID = raw_input('What is your netmask identifier?: ')
@@ -121,7 +121,7 @@ if setupStaticIP == 'Y' or 'y':
 	If the response is a yes, update the interfaces file to include the gateway identifier and the
 	relevant functionality.
 	'''
-	if setupGateway == 'Y' or 'y':
+	if setupGateway == 'Y' or setupGateway == 'y':
 
 		# Ask for the gateway identifier.
 		gateway_ID = raw_input('What is your gateway identifier?: ')
@@ -137,7 +137,7 @@ if setupStaticIP == 'Y' or 'y':
 	If the response is a yes, update the interfaces file to include the DNS server names and the
 	relevant functionality.
 	'''
-	if setupDNSserver == 'Y' or 'y':
+	if setupDNSserver == 'Y' or setupDNSserver == 'y':
 
 		# Ask for the DNS server names.
 		name1 = raw_input('What is the IP of the first DNS server?: ')
@@ -151,7 +151,7 @@ if setupStaticIP == 'Y' or 'y':
 restoreBackup = raw_input('Would you like to restore the backup of the network interfaces update (Y/N)?: ')
 
 # If the response is a yes, copy the backup over the original file that has been modified.
-if restoreBackup == 'Y' or 'y':
+if restoreBackup == 'Y' or restoreBackup == 'y':
 
 	# Restore the backup interfaces file using the cp linux command with root access.
 	os.system('sudo cp /etc/network/interfaces_backup /etc/network/interfaces')

--- a/station-update.py
+++ b/station-update.py
@@ -104,9 +104,9 @@ def dynamic_restore(static, netmask, gateway):
     dynamic IP call and commenting out the static IP calls.
     '''
     interfaces_update('# replace for dynamic IP configuration' + '\n' +
-                      '# iface eth0 inet dhcp\n', 'iface eth0 inet dhcp')
+                      '# iface eth0 inet dhcp', 'iface eth0 inet dhcp\n')
     interfaces_update('# auto eth0', 'auto eth0' + '\n')
-    interfaces_update('# iface eth0 inet static', 'iface eth0 inet static' +
+    interfaces_update('iface eth0 inet static', '# iface eth0 inet static' +
                       '\n')
 
     # Update the interfaces file with the static IP by uncommenting out

--- a/station-update.py
+++ b/station-update.py
@@ -107,7 +107,7 @@ If the response is a no, simply let the user know the script will henceforth
 assume that there is a csv file, and continue with the script.
 '''
 
-while csv_copy.lower() not 'y' or 'n':
+while (csv_copy.lower() != 'y') or (csv_copy.lower() != 'n'):
 
     # Let the user know a valid response is required for the question.
     print('Please provide a valid "y" or "n" response.')

--- a/station-update.py
+++ b/station-update.py
@@ -42,6 +42,8 @@ Loop through each line of the interfaces file to find the default station ID pla
 by the user.
 '''
 
+temp = sys.stdout
+
 # Open the interfaces file for writing using the print statement and write to a temporary file.
 sys.stdin = open('/etc/network/interfaces', 'r')
 sys.stdout = open('~interfaces_temp', 'w')
@@ -58,6 +60,8 @@ for line in fileinput.input('/etc/network/interfaces'):
 l = os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
 
 sys.stdout.close()
+
+sys.stdout = temp
 
 # Print the scp linux command that was executed for debugging purposes.
 print 'FOR DEBUGGING, linux command: %s' % l

--- a/station-update.py
+++ b/station-update.py
@@ -17,11 +17,11 @@ NAME = raw_input('What is the csv file name?: ')
 print 'FOR DEGUBBING, csv file name: %s' % NAME
 
 # Define the paths to the source and target .csv files as arguments for the scp linux command to be executed through the Popen function.
-sourcePath = ' dosenet@dosenet.dhcp.lbl.gov:~/config-files/ ' + NAME
-targetPath = ' /home/pi/config/config.csv'
+sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/'
+targetPath = '/home/pi/config/config.csv'
 
 # Execute the linux command line to securely copy the file over the Internet. Wait until it executes for this Python script to continue.
-p = os.system('scp' + sourcePath + targetPath)
+p = os.system('scp "%s" "%s:%s"' % (NAME, sourcePath, targetPath))
 
 # Print the scp linux command that was executed for debugging purposes.
 print 'FOR DEBUGGING, linux command: ', p

--- a/station-update.py
+++ b/station-update.py
@@ -161,6 +161,3 @@ if restoreBackup == 'Y' or 'y':
 
 	# Alert the user that the backup interfaces file has been restored and to rerun the script if they want to re-setup the network configuration.
 	print 'The network interfaces file has been restored from the backup. Run this python script again to setup the network configuration again.'
-
-	
-	#

--- a/station-update.py
+++ b/station-update.py
@@ -137,7 +137,7 @@ if csv_copy.lower() == 'y':
     # Internet.
     os.system('scp {} {}'.format(sourcePath, targetPath))
 
-if csv_copy.lower() == 'n':
+elif csv_copy.lower() == 'n':
 
     raw_input('\nNote: There must be a network configuration file to ' +
               'properly configure the network options. Please double-check ' +
@@ -182,7 +182,7 @@ If the response is a yes, update the interfaces file to include the static IP
 and the relevant functionality.
 '''
 
-while setup_static_ip.lower() != 'y' or 'n':
+while setup_static_ip.lower() not in ('y', 'n'):
 
     # Let the user know a valid response is required for the question.
     print('Please provide a valid "y" or "n" response.')
@@ -208,7 +208,7 @@ if setup_static_ip.lower() == 'n':
     network interfaces file.
     '''
 
-    while keep_changes.lower() != 'y' or 'n':
+    while keep_changes.lower() not in ('y', 'n'):
 
         # Let the user know a valid response is required for the question.
         print('Please provide a valid "y" or "n" response.')
@@ -261,7 +261,7 @@ elif setup_static_ip.lower() == 'y':
     identifier and the relevant functionality.
     '''
 
-    while setup_netmask.lower() != 'y' or 'n':
+    while setup_netmask.lower() not in ('y', 'n'):
 
         # Let the user know a valid response is required for the question.
         print('Please provide a valid "y" or "n" response.')
@@ -287,7 +287,7 @@ elif setup_static_ip.lower() == 'y':
         network interfaces file.
         '''
 
-        while keep_changes.lower() != 'y' or 'n':
+        while keep_changes.lower() not in ('y', 'n'):
 
             # Let the user know a valid response is required for the question.
             print('Please provide a valid "y" or "n" response.')
@@ -337,7 +337,7 @@ elif setup_static_ip.lower() == 'y':
     identifier and the relevant functionality.
     '''
 
-    while setup_gateway.lower() != 'y' or 'n':
+    while setup_gateway.lower() not in ('y', 'n'):
 
         # Let the user know a valid response is required for the question.
         print('Please provide a valid "y" or "n" response.')
@@ -363,7 +363,7 @@ elif setup_static_ip.lower() == 'y':
         network interfaces file.
         '''
 
-        while keep_changes.lower() != 'y' or 'n':
+        while keep_changes.lower() not in ('y', 'n'):
 
             # Let the user know a valid response is required for the question.
             print('Please provide a valid "y" or "n" response.')
@@ -418,7 +418,7 @@ elif setup_static_ip.lower() == 'y':
     If the response is a yes, update the interfaces file to include the DNS
     server names and the relevant functionality.
     '''
-    while setup_dns_server.lower() != 'y' or 'n':
+    while setup_dns_server.lower() not in ('y', 'n'):
 
         # Let the user know a valid response is required for the question.
         print('Please provide a valid "y" or "n" response.')
@@ -445,7 +445,7 @@ elif setup_static_ip.lower() == 'y':
         network interfaces file.
         '''
 
-        while keep_changes.lower() != 'y' or 'n':
+        while keep_changes.lower() not in ('y', 'n'):
 
             # Let the user know a valid response is required for the question.
             print('Please provide a valid "y" or "n" response.')
@@ -513,7 +513,7 @@ If the response is a no (or anything else), restore the backup to the
 network interfaces file.
 '''
 
-while keep_changes.lower() != 'y' or 'n':
+while keep_changes.lower() not in ('y', 'n'):
 
     # Let the user know a valid response is required for the question.
     print('Please provide a valid "y" or "n" response.')

--- a/station-update.py
+++ b/station-update.py
@@ -133,7 +133,7 @@ if setup_static_ip.lower() == 'n':
     If the response is a no (or anything else), restore the backup to the
     network interfaces file.
     '''
-    if keep_changes.lower() is 'y':
+    if keep_changes.lower() == 'y':
 
         print('\nA dynamic IP has been set. Your Pi-hat sensor module now ' +
               'has updated network functionality and the appropriate ' +

--- a/station-update.py
+++ b/station-update.py
@@ -35,6 +35,9 @@ os.system('sudo cp /etc/network/interfaces /etc/network/interfaces_backup')
 # Alert the user that a backup file has been made.
 print 'A backup of the network interfaces file has been made. If you make an error during the rest of the setup, a prompt at the end will ask if you would like to restore the backup.'
 
+# Ask for the station ID and output the raw input string as a variable.
+ID = raw_input('What is the station ID?: ')
+
 '''
 Define a function to update the interfaces file by replacing the line containing an indicated phrase with a new line.
 '''
@@ -70,9 +73,6 @@ def interfacesUpdate(repPhrase, newLine):
 
 	# Return the original standard output.
 	sys.stdout = temp
-
-# Ask for the station ID and output the raw input string as a variable.
-ID = raw_input('What is the station ID?: ')
 
 # Update the station using the update function.
 interfacesUpdate('wireless-essid RPiAdHocNetwork', '  wireless-essid RPiAdHocNetwork%s' % ID + '\n')

--- a/station-update.py
+++ b/station-update.py
@@ -170,10 +170,10 @@ if setup_static_ip is 'y':
         # Update the interfaces file with the DNS server names by uncommenting
         # out the DNS server names call. Do it sequentially.
         interfaces_update('#   dns-nameservers ',
-                          '  dns-nameservers {}'.format(dns_server_1) + '\n')
-            
-        interfaces_update('#   dns-nameservers ',
                           '  dns-nameservers {}'.format(dns_server_2) + '\n')
+            
+        interfaces_update('  dns-nameservers ',
+                          '  dns-nameservers {} '.format(dns_server_1) + '\n')
 
 # Ask the user if they would like to restore the backup to the network
 # interfaces file.

--- a/station-update.py
+++ b/station-update.py
@@ -14,11 +14,8 @@ from subprocess import Popen
 # Ask the user for the csv file name.
 NAME = input("What is the csv file name?:")
 
-# Define the linux command line to pass into the top-level shell to preform the secure copy functionality.
-args = ("scp", ("dosenet@dosenet.dhcp.lbl.gov:~/config-files/" + NAME), "/home/pi/config/config.csv")
-
 # Execute the linux command line and wait until it executes for the script to continue.
-p = Popen(args).wait()
+p = Popen("scp", ("dosenet@dosenet.dhcp.lbl.gov:~/config-files/" + NAME), "/home/pi/config/config.csv").wait()
 
 # Ask for the station ID.
 ID = input("What is the station ID?:")

--- a/station-update.py
+++ b/station-update.py
@@ -10,10 +10,7 @@ DNS-server names.
 import fileinput
 import sys
 import os
-
 from tempfile import mkstemp
-from shutil import move
-from os import remove, close
 
 '''
 Part 1: Securely copying the network configuration file from the Dosenet servers to the Pi-hat.
@@ -50,19 +47,19 @@ def interfacesUpdate(repPhrase, newLine):
 	tempFile, tempPath = mkstemp()
 	
 	with open(tempPath, 'w') as tempInterfaces:
-		with open('/etc/network/interfaces', 'w') as oldInterfaces:
+		with open('/etc/network/interfaces', 'r') as oldInterfaces:
 			for line in oldInterfaces:
 				tempInterfaces.write(line.replace(repPhrase, newLine))
 				
-	close(tempFile)
+	os.close(tempFile)
 	
     	# Move the updated interfaces file to replace the old interfaces file using root access.
-	os.system('sudo mv ~interfaces_temp /etc/network/interfaces')
-				
+	os.system('sudo mv %s /etc/network/interfaces' % tempPath)
+	
 	'''
-
-	# Store the original standard output.
-	temp = sys.stdout
+	# Store the original standard input and output.
+	tempIn = sys.stdin
+	tempOut = sys.stdout
 
 	# Open the interfaces file for reading and open up a temporary file for writing using the standard input and output functions.
 	sys.stdin = open('/etc/network/interfaces', 'r')
@@ -91,23 +88,23 @@ def interfacesUpdate(repPhrase, newLine):
 	# Close the interfaces files for reading and writing
 	sys.stdout.close()
 
-	# Return the original standard output.
-	sys.stdout = temp
-	
+	# Return the original standard input and output.
+	sys.stdin = tempIn
+	sys.stdout = tempOut
 	'''
 
 # Update the station using the update function.
 interfacesUpdate('wireless-essid RPiAdHocNetwork', '  wireless-essid RPiAdHocNetwork%s' % ID + '\n')
 
 # Ask the user if they would like to use a static IP.
-setupStaticIP = raw_input('Do you want to set a static IP (Y/N)?: ')
+setupStaticIP = raw_input('Do you want to set a static IP (y/n)?: ')
 	
 print setupStaticIP
 
 '''
 If the response is a yes, update the interfaces file to include the static IP and the relevant functionality.
 '''
-if setupStaticIP:
+if setupStaticIP is 'y':
 	
 	print setupStaticIP
 
@@ -116,26 +113,26 @@ if setupStaticIP:
 
 	# Update the interfaces file with the static IP by commenting out the dynamic IP call and
 	# uncommenting out the static IP calls. 
-	interfacesUpdate('iface eth0 inet dhcp', '# replace for dynamic IP configuration\n# iface eth0 inet dhcp')
-	interfacesUpdate('# auto eth0', 'auto eth0')
-	interfacesUpdate('# iface eth0 inet static', 'iface eth0 inet static')
-	interfacesUpdate('#   address', '  address %s' % IP_static)
+	interfacesUpdate('iface eth0 inet dhcp', '# replace for dynamic IP configuration\n# iface eth0 inet dhcp' + '\n')
+	interfacesUpdate('# auto eth0', 'auto eth0' + '\n')
+	interfacesUpdate('# iface eth0 inet static', 'iface eth0 inet static' + '\n')
+	interfacesUpdate('#   address', '  address %s' % IP_static + '\n')
 
 	# Ask the user if they have a netmask.
-	setupNetmask = raw_input('Do you have a netmask (Y/N)?: ')
+	setupNetmask = raw_input('Do you have a netmask (y/n)?: ')
 
 	'''
 	If the response is a yes, update the interfaces file to include the netmask identifier and the
 	relevant functionality.
 	'''
-	if setupNetmask is 'Y' or 'y':
+	if setupNetmask is 'y':
 
 		# Ask for the netmask identifier.
 		netmask_ID = raw_input('What is your netmask identifier?: ')
 
 		# Update the interfaces file with the netmask identifier by uncommenting out the netmask
 		# call.
-		interfacesUpdate('#   netmask', '  netmask %s' % netmask_ID)
+		interfacesUpdate('#   netmask', '  netmask %s' % netmask_ID + '\n')
 
 	# Ask the user if they have a gateway.
 	setupGateway = raw_input('Do you have a gateway (y/n)?: ')
@@ -151,16 +148,16 @@ if setupStaticIP:
 
 		# Update the interfaces file with the gateway identifier by uncommenting out the gateway
 		# call.
-		interfacesUpdate('#   gateway', '  gateway %s' % gateway_ID)
+		interfacesUpdate('#   gateway', '  gateway %s' % gateway_ID + '\n')
 
 	# Ask the user if they have DNS servers connected.
-	setupDNSserver = raw_input('Do you have DNS servers connected (Y/N)?: ')
+	setupDNSserver = raw_input('Do you have DNS servers connected (y/n)?: ')
 
 	'''
 	If the response is a yes, update the interfaces file to include the DNS server names and the
 	relevant functionality.
 	'''
-	if setupDNSserver is 'Y' or 'y':
+	if setupDNSserver is 'y':
 
 		# Ask for the DNS server names.
 		name1 = raw_input('What is the IP of the first DNS server?: ')
@@ -168,13 +165,13 @@ if setupStaticIP:
 
 		# Update the interfaces file with the DNS server names by uncommenting out the DNS server
 		# names call.
-		interfacesUpdate('#   dns-nameservers ', '  dns-nameservers "%s" "%s"' % (name1, name2))
+		interfacesUpdate('#   dns-nameservers ', '  dns-nameservers "%s" "%s"' % (name1, name2) + '\n')
 
 # Ask the user if they would like to restore the backup to the network interfaces file.
-restoreBackup = raw_input('Would you like to restore the backup of the network interfaces update (Y/N)?: ')
+restoreBackup = raw_input('Would you like to restore the backup of the network interfaces update (y/n)?: ')
 
 # If the response is a yes, copy the backup over the original file that has been modified.
-if restoreBackup is 'Y' or 'y':
+if restoreBackup is 'y':
 
 	# Restore the backup interfaces file using the cp linux command with root access.
 	os.system('sudo cp /etc/network/interfaces_backup /etc/network/interfaces')

--- a/station-update.py
+++ b/station-update.py
@@ -105,7 +105,7 @@ def dynamic_restore(static, netmask, gateway):
     '''
     interfaces_update('# replace for dynamic IP configuration', '')
     interfaces_update('# iface eth0 inet dhcp', 'iface eth0 inet dhcp\n')
-    interfaces_update('# auto eth0', 'auto eth0' + '\n')
+    interfaces_update('auto eth0', '# auto eth0' + '\n')
     interfaces_update('iface eth0 inet static', '# iface eth0 inet static' +
                       '\n')
 

--- a/station-update.py
+++ b/station-update.py
@@ -12,17 +12,17 @@ import os
 from subprocess import Popen
 
 # Ask the user for the csv file name.
-NAME = input("What is the csv file name?: ")
+NAME = input('What is the csv file name?: ')
 
 # Print the csv file name inputed by the user for debugging purposes.
 print 'FOR DEGUBBING, csv file name: ', NAME
 
-# Define the arguments to the scp linux command to be executed through the Popen function
-arg1 = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + str(NAME)
-arg2 = '/home/pi/config/config.csv'
+# Define the paths to the source and target .csv files as arguments for the scp linux command to be executed through the Popen function.
+sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + str(NAME)
+targetPath = '/home/pi/config/config.csv'
 
-# Execute the linux command line. Wait until it executes for this Python script to continue.
-p = Popen(['scp', arg1, arg2]).wait()
+# Execute the linux command line to securely copy the file over the Internet. Wait until it executes for this Python script to continue.
+p = Popen(['scp', sourcePath, targetPath]).wait()
 
 # Print the scp linux command that was executed for debugging purposes.
 print 'FOR DEBUGGING, linux command: ', p
@@ -32,7 +32,21 @@ Part 2: Updating the dosimeter ID on the network configuration file on the Pi-ha
 '''
 
 # Ask for the station ID.
-ID = input("What is the station ID?: ")
+ID = input('What is the station ID?: ')
+
+# Open the interfaces file (and call a file handle for it within the program) and update the network ID.
+with open('/etc/network/interfaces/interfaces', '+') as netConfig:
+  # Search line by line in the interfaces file.
+  for line in netConfig:
+    # Search for 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
+    if 'wireless-essid' in line:
+      # Create a handle for a new line with the updated station ID to input into the interfaces file.      
+      line = 'wireless-essid RPiAdHocNetwork' + ID + '\n'
+      netConfig.write(line)
+
+
+'''
+Optional backup section, only works with Python 3.3 and later.
 
 # Open the relevant directory to read/write the network ID on the Pi-hat.
 dirConfig = os.open('/etc/network/interfaces')
@@ -50,3 +64,7 @@ with open('interfaces', '+', opener=opendir) as netConfig:
       # Create a handle for a new line with the updated station ID to input into the interfaces file.      
       line = 'wireless-essid RPiAdHocNetwork' + ID + '\n'
       netConfig.write(line)
+
+# Close the file directory
+os.close(dirConfig)
+'''

--- a/station-update.py
+++ b/station-update.py
@@ -52,7 +52,7 @@ for line in fileinput.input('/etc/network/interfaces'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
     if 'wireless-essid' in line:
         # Create a handle for a new line with the updated station ID to input into the interfaces file.      
-        line = '  wireless-essid RPiAdHocNetwork' + ID + '/n'
+        line = '  wireless-essid RPiAdHocNetwork' + ID + '\n'
     
     # Write the new line with the updated station ID in the interfaces file.
     sys.stdout.write(line)

--- a/station-update.py
+++ b/station-update.py
@@ -120,7 +120,7 @@ and the relevant functionality.
 '''
 print('\nFor debugging: ' + setup_static_ip)
 
-if setup_static_ip.lower() is 'n':
+if setup_static_ip.lower() == 'n':
 
     print('\nFor debugging: ' + setup_static_ip)
 

--- a/station-update.py
+++ b/station-update.py
@@ -299,6 +299,11 @@ elif setup_static_ip.lower() == 'y':
 
         if keep_changes.lower() == 'y':
 
+            # Update the interfaces file with the static IP by commenting out
+            # the static IP call.
+            interfaces_update('  address {}'.format(netmask_id), '#   ' +
+                              'address\n')
+
             print('\nA static IP has not been set (requires a netmask, ' +
                   'a gateway, and DNS server names) and a dynamic IP will ' +
                   'remain. Your Pi-hat sensor module now has updated ' +
@@ -374,6 +379,11 @@ elif setup_static_ip.lower() == 'y':
                                      'changes (y/n)?: ')
 
         if keep_changes.lower() == 'y':
+
+            # Update the interfaces file with the static IP by commenting out
+            # the static IP call.
+            interfaces_update('  address {}'.format(netmask_id), '#   ' +
+                              'address\n')
 
             # Update the interfaces file with the netmask identifier by
             # commenting out the netmask call.
@@ -456,6 +466,11 @@ elif setup_static_ip.lower() == 'y':
                                      'changes (y/n)?: ')
 
         if keep_changes.lower() == 'y':
+
+            # Update the interfaces file with the static IP by commenting out
+            # the static IP call.
+            interfaces_update('  address {}'.format(netmask_id), '#   ' +
+                              'address\n')
 
             # Remove the netmask and gateway identifiers from the interfaces
             # file by commenting them out.

--- a/station-update.py
+++ b/station-update.py
@@ -59,8 +59,8 @@ def interfacesUpdate(repPhrase, newLine):
 	os.system('sudo mv %s /etc/network/interfaces' % tempPath)
 	'''
 	
-	'''
 	# METHOD 2
+	
 	# Store the original standard input and output.
 	tempIn = sys.stdin
 	tempOut = sys.stdout
@@ -68,12 +68,11 @@ def interfacesUpdate(repPhrase, newLine):
 	# Open the interfaces file for reading and open up a temporary file for writing using the standard input and output functions.
 	sys.stdin = open('/etc/network/interfaces', 'r')
 	sys.stdout = open('~interfaces_temp', 'w')
-
-	'''
+	
 	'''
 	Loop through each line of the interfaces file to find the phrase of interest and replace it with the new line.
 	'''
-	'''
+	
 	for line in fileinput.input('/etc/network/interfaces'):
 
 		# Search and find the phrase of interest to indicate the place in the code to replace the original line with
@@ -95,7 +94,6 @@ def interfacesUpdate(repPhrase, newLine):
 	# Return the original standard input and output.
 	sys.stdin = tempIn
 	sys.stdout = tempOut
-	'''
 
 # Update the station using the update function.
 interfacesUpdate('wireless-essid RPiAdHocNetwork', '  wireless-essid RPiAdHocNetwork%s' % ID + '\n')

--- a/station-update.py
+++ b/station-update.py
@@ -17,14 +17,14 @@ NAME = raw_input('What is the csv file name?: ')
 print 'FOR DEGUBBING, csv file name: %s' % NAME
 
 # Define the paths to the source and target .csv files as arguments for the scp linux command to be executed through the Popen function.
-sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/'
+sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
 targetPath = '/home/pi/config/config.csv'
 
 # Execute the linux command line to securely copy the file over the Internet. Wait until it executes for this Python script to continue.
-p = os.system('scp "%s" "%s:%s"' % (NAME, sourcePath, targetPath))
+p = os.system('scp "%s" "%s"' % (sourcePath, targetPath))
 
 # Print the scp linux command that was executed for debugging purposes.
-print 'FOR DEBUGGING, linux command: ', p
+print 'FOR DEBUGGING, linux command: %s' % p
 
 '''
 Part 2: Updating the dosimeter ID on the network configuration file on the Pi-hat once it has been copied securely over the Internet.

--- a/station-update.py
+++ b/station-update.py
@@ -21,7 +21,7 @@ sourcePath = ' dosenet@dosenet.dhcp.lbl.gov:~/config-files/ ' + NAME
 targetPath = ' /home/pi/config/config.csv'
 
 # Execute the linux command line to securely copy the file over the Internet. Wait until it executes for this Python script to continue.
-p = os.system('scp' + sourcePath + targetPath).wait()
+p = os.system('scp' + sourcePath + targetPath)
 
 # Print the scp linux command that was executed for debugging purposes.
 print 'FOR DEBUGGING, linux command: ', p

--- a/station-update.py
+++ b/station-update.py
@@ -9,7 +9,6 @@ Part 1: Securely copying the network configuration file from the Dosenet servers
 
 # Import the relevant modules and functions from the appropriate libraries for convenience. 
 import os
-from subprocess import Popen
 
 # Ask the user for the csv file name.
 NAME = raw_input('What is the csv file name?: ')
@@ -22,7 +21,7 @@ sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
 targetPath = '/home/pi/config/config.csv'
 
 # Execute the linux command line to securely copy the file over the Internet. Wait until it executes for this Python script to continue.
-p = Popen(['scp', sourcePath, targetPath]).wait()
+p = os.system(['scp' + sourcePath + targetPath]).wait()
 
 # Print the scp linux command that was executed for debugging purposes.
 print 'FOR DEBUGGING, linux command: ', p

--- a/station-update.py
+++ b/station-update.py
@@ -86,7 +86,7 @@ setupStaticIP = raw_input('Do you want to set a static IP (Y/N)?: ')
 '''
 If the response is a yes, update the interfaces file to include the static IP and the relevant functionality.
 '''
-if setupStaticIP == 'Y' or setupStaticIP == 'y':
+if setupStaticIP is 'Y' or 'y':
 
 	# Ask for the static IP.
 	IP_static = raw_input('What is your static IP?: ')
@@ -105,7 +105,7 @@ if setupStaticIP == 'Y' or setupStaticIP == 'y':
 	If the response is a yes, update the interfaces file to include the netmask identifier and the
 	relevant functionality.
 	'''
-	if setupNetmask == 'Y' or setupNetmask == 'y':
+	if setupNetmask is 'Y' or 'y':
 
 		# Ask for the netmask identifier.
 		netmask_ID = raw_input('What is your netmask identifier?: ')
@@ -121,7 +121,7 @@ if setupStaticIP == 'Y' or setupStaticIP == 'y':
 	If the response is a yes, update the interfaces file to include the gateway identifier and the
 	relevant functionality.
 	'''
-	if setupGateway == 'Y' or setupGateway == 'y':
+	if setupGateway is 'Y' or 'y':
 
 		# Ask for the gateway identifier.
 		gateway_ID = raw_input('What is your gateway identifier?: ')
@@ -137,7 +137,7 @@ if setupStaticIP == 'Y' or setupStaticIP == 'y':
 	If the response is a yes, update the interfaces file to include the DNS server names and the
 	relevant functionality.
 	'''
-	if setupDNSserver == 'Y' or setupDNSserver == 'y':
+	if setupDNSserver is 'Y' or 'y':
 
 		# Ask for the DNS server names.
 		name1 = raw_input('What is the IP of the first DNS server?: ')
@@ -151,7 +151,7 @@ if setupStaticIP == 'Y' or setupStaticIP == 'y':
 restoreBackup = raw_input('Would you like to restore the backup of the network interfaces update (Y/N)?: ')
 
 # If the response is a yes, copy the backup over the original file that has been modified.
-if restoreBackup == 'Y' or restoreBackup == 'y':
+if restoreBackup is 'Y' or 'y':
 
 	# Restore the backup interfaces file using the cp linux command with root access.
 	os.system('sudo cp /etc/network/interfaces_backup /etc/network/interfaces')

--- a/station-update.py
+++ b/station-update.py
@@ -21,7 +21,7 @@ args2 = '/home/pi/config/config.csv'
 print 'scp', args1, args2
 
 # Execute the linux command line and wait until it executes for the script to continue.
-p = Popen("scp", args1, args2, bufsize=-1).wait()
+p = Popen("scp", [args1 + ' ' + args2], bufsize=-1).wait()
 
 print ("linux command: ", p)
 

--- a/station-update.py
+++ b/station-update.py
@@ -16,10 +16,8 @@ NAME = input("What is the csv file name?:")
 
 print 'csv file name: ', NAME
 
-
-
 # Execute the linux command line and wait until it executes for the script to continue.
-p = Popen("scp", ["dosenet@dosenet.dhcp.lbl.gov:~/config-files/", str(NAME), "/home/pi/config/config.csv").wait()
+p = Popen("scp", "dosenet@dosenet.dhcp.lbl.gov:~/config-files/", str(NAME), "/home/pi/config/config.csv").wait()
 
 print ("linux command: ", p)
 

--- a/station-update.py
+++ b/station-update.py
@@ -41,6 +41,10 @@ ID = raw_input('What is the station ID?: ')
 Loop through each line of the interfaces file to find the default station ID placeholder and replace it with the station ID provided
 by the user.
 '''
+
+# Open the interfaces file for writing using the print statement.
+sys.stdout = open('/etc/network/interfaces', 'w')
+
 for line in fileinput.input('/etc/network/interfaces'):
     # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
     if 'wireless-essid' in line:
@@ -48,4 +52,4 @@ for line in fileinput.input('/etc/network/interfaces'):
         line = '  wireless-essid RPiAdHocNetwork' + ID + '\n'
     
     # Write the new line with the updated station ID in the interfaces file.
-    sys.stdout.write(line)
+    print line

--- a/station-update.py
+++ b/station-update.py
@@ -16,11 +16,12 @@ NAME = input("What is the csv file name?:")
 
 print 'csv file name: ', NAME
 
-args = 'scp dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME + ' /home/pi/config/config.csv'
-print args
+args1 = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
+args2 = '/home/pi/config/config.csv'
+print 'scp' args1 + args2
 
 # Execute the linux command line and wait until it executes for the script to continue.
-p = Popen(args).wait()
+p = Popen("scp", args1, args2).wait()
 
 print ("linux command: ", p)
 

--- a/station-update.py
+++ b/station-update.py
@@ -87,7 +87,42 @@ def backup_restore():
           'script again to setup the network configuration again.')
 
 '''
-Part 3: Securely copy the network configuration (csv) file from the Dosenet
+Part 3: Define a function to restore the dynamic IP configuration if a faulty
+        static IP configuration has been set (i.e., one without one of the
+        following: netmask, gateway, DNS server names).
+
+        Namely, the static IP, netmask, and gateway calls are commented out
+        and the dynamic IP calls are uncommented out. The DNS server names are
+        unaffected as they
+'''
+
+
+def dynamic_restore(static, netmask, gateway):
+    """Function to restore the dynamic IP configuration."""
+    '''
+    Update the interfaces file with the dynamic IP by uncommenting out the
+    dynamic IP call and commenting out the static IP calls.
+    '''
+    interfaces_update('# replace for dynamic IP configuration' + '\n' +
+                      '# iface eth0 inet dhcp\n', 'iface eth0 inet dhcp')
+    interfaces_update('# auto eth0', 'auto eth0' + '\n')
+    interfaces_update('# iface eth0 inet static', 'iface eth0 inet static' +
+                      '\n')
+
+    # Update the interfaces file with the static IP by uncommenting out
+    # the static IP call.
+    interfaces_update('  address {}'.format(static), '#   address\n')
+
+    # Remove the netmask and gateway identifiers from the interfaces
+    # file by commenting them out.
+    interfaces_update('  netmask {}'.format(netmask), '#   ' +
+                      'netmask\n')
+
+    interfaces_update('  gateway {}'.format(gateway), '#   ' +
+                      'gateway\n')
+
+'''
+Part 4: Securely copy the network configuration (csv) file from the Dosenet
         servers to the Raspberry Pi if the user so wishes.
 '''
 
@@ -146,7 +181,7 @@ elif csv_copy.lower() == 'n':
               'key to continue. ')
 
 '''
-Part 4: Update the dosimeter ID on the network configuration file on the
+Part 5: Update the dosimeter ID on the network configuration file on the
         Raspberry Pi once it has been copied securely over the Internet.
 '''
 
@@ -299,10 +334,8 @@ elif setup_static_ip.lower() == 'y':
 
         if keep_changes.lower() == 'y':
 
-            # Update the interfaces file with the static IP by commenting out
-            # the static IP call.
-            interfaces_update('  address {}'.format(ip_static), '#   ' +
-                              'address\n')
+            # Restore the dynamic IP configuration.
+            dynamic_restore(ip_static, 'dummy', 'dummy')
 
             print('\nA static IP has not been set (requires a netmask, ' +
                   'a gateway, and DNS server names) and a dynamic IP will ' +
@@ -380,15 +413,8 @@ elif setup_static_ip.lower() == 'y':
 
         if keep_changes.lower() == 'y':
 
-            # Update the interfaces file with the static IP by commenting out
-            # the static IP call.
-            interfaces_update('  address {}'.format(ip_static), '#   ' +
-                              'address\n')
-
-            # Update the interfaces file with the netmask identifier by
-            # commenting out the netmask call.
-            interfaces_update('  netmask {}'.format(netmask_id), '#   ' +
-                              'netmask\n')
+            # Restore the dynamic IP configuration.
+            dynamic_restore(ip_static, netmask_id, 'dummy')
 
             print('\nA static IP has not been set (requires a netmask, ' +
                   'a gateway, and DNS server names) and a dynamic IP will ' +
@@ -467,18 +493,8 @@ elif setup_static_ip.lower() == 'y':
 
         if keep_changes.lower() == 'y':
 
-            # Update the interfaces file with the static IP by commenting out
-            # the static IP call.
-            interfaces_update('  address {}'.format(ip_static), '#   ' +
-                              'address\n')
-
-            # Remove the netmask and gateway identifiers from the interfaces
-            # file by commenting them out.
-            interfaces_update('  netmask {}'.format(netmask_id), '#   ' +
-                              'netmask\n')
-
-            interfaces_update('  gateway {}'.format(gateway_id), '#   ' +
-                              'gateway\n')
+            # Restore the dynamic IP configuration.
+            dynamic_restore(ip_static, netmask_id, gateway_id)
 
             print('\nA static IP has not been set (requires a netmask, ' +
                   'a gateway, and DNS server names) and a dynamic IP will ' +
@@ -508,7 +524,7 @@ elif setup_static_ip.lower() == 'y':
                           "{} {}".format(dns_server_1, dns_server_2) + '\n')
 
 '''
-Part 5: Perform a final check on whether the user wants to keep the changes
+Part 6: Perform a final check on whether the user wants to keep the changes
         to the interfaces file and output the results of the configuration of
         a static IP if the script has not been exited at this point.
 '''

--- a/station-update.py
+++ b/station-update.py
@@ -1,0 +1,45 @@
+# Author: Yaro Kaminskiy
+
+# Use the built-in subprocess module and open function to securely copy the Pi-hat network configuration file from the Dosenet servers
+# to a Pi-hat at a school of interest and to update the network ID on the network configuration file for a Pi-hat using a search algorithm.
+
+'''
+Part 1: Securely copying the network configuration file from the Dosenet servers to the Pi-hat.
+'''
+
+# Import the relevant modules and functions from the appropriate libraries for convenience. 
+import os
+from subprocess import Popen
+
+# Ask the user for the csv file name.
+NAME = input("What is the csv file name?:")
+
+# Define the linux command line to pass into the top-level shell to preform the secure copy functionality.
+args = ("scp", ("dosenet@dosenet.dhcp.lbl.gov:~/config-files/" + NAME), "/home/pi/config/config.csv")
+
+# Execute the linux command line and wait until it executes for the script to continue.
+p = Popen(args).wait()
+
+# Ask for the station ID.
+ID = input("What is the station ID?:")
+
+'''
+Part 2: Updating the dosimeter ID on the network configuration file on the Pi-hat once it has been copied securely over the Internet.
+'''
+
+# Open the relevant directory to read/write the network ID on the Pi-hat.
+dirConfig = os.open('/etc/network/interfaces')
+
+# Define a function to open files within the directory of interest.
+def opendir(path, flags):
+  return os.open(path, flags, dir_fd=dirConfig)
+
+# Open the interfaces file (and call a file handle for it within the program) and update the network ID.
+with open('interfaces', '+', opener=opendir) as netConfig:
+  # Search line by line in the interfaces file.
+  for line in netConfig:
+    # Search for 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
+    if 'wireless-essid' in line:
+      # Create a handle for a new line with the updated station ID to input into the interfaces file.      
+      line = 'wireless-essid RPiAdHocNetwork' + ID + '\n'
+      netConfig.write(line)

--- a/station-update.py
+++ b/station-update.py
@@ -136,7 +136,7 @@ if setup_static_ip.lower() == 'n':
     If the response is a no (or anything else), restore the backup to the
     network interfaces file.
     '''
-    if keep_changes.lower() is 'y':
+    if keep_changes.lower() == 'y':
 
         print('\nA dynamic IP has been set. Your Pi-hat sensor module now ' +
               'has updated network functionality and the appropriate ' +
@@ -158,7 +158,7 @@ if setup_static_ip.lower() == 'n':
 
     sys.exit()
 
-elif setup_static_ip.lower() is 'y':
+elif setup_static_ip.lower() == 'y':
 
     # Ask for the static IP.
     ip_static = raw_input('\nWhat is your static IP?: ')
@@ -183,7 +183,7 @@ elif setup_static_ip.lower() is 'y':
     If the response is a yes, update the interfaces file to include the netmask
     identifier and the relevant functionality.
     '''
-    if setup_netmask.lower() is 'n':
+    if setup_netmask.lower() == 'n':
 
         # Ask the user if they would like to keep the changes to the network
         # interfaces file.
@@ -197,7 +197,7 @@ elif setup_static_ip.lower() is 'y':
         If the response is a no (or anything else), restore the backup to the
         network interfaces file.
         '''
-        if keep_changes.lower() is 'y':
+        if keep_changes.lower() == 'y':
 
             print('\nA static IP has not been set (requires a netmask, ' +
                   'a gateway, and DNS server names) and a dynamic IP will ' +
@@ -221,7 +221,7 @@ elif setup_static_ip.lower() is 'y':
 
         sys.exit()
 
-    elif setup_netmask.lower() is 'y':
+    elif setup_netmask.lower() == 'y':
 
         # Ask for the netmask identifier.
         netmask_id = raw_input('\nWhat is your netmask identifier?: ')
@@ -241,7 +241,7 @@ elif setup_static_ip.lower() is 'y':
     If the response is a yes, update the interfaces file to include the gateway
     identifier and the relevant functionality.
     '''
-    if setup_gateway.lower() is 'n':
+    if setup_gateway.lower() == 'n':
 
         # Ask the user if they would like to keep the changes to the network
         # interfaces file.
@@ -255,7 +255,7 @@ elif setup_static_ip.lower() is 'y':
         If the response is a no (or anything else), restore the backup to the
         network interfaces file.
         '''
-        if keep_changes.lower() is 'y':
+        if keep_changes.lower() == 'y':
 
             print('\nA static IP has not been set (requires a netmask, ' +
                   'a gateway, and DNS server names) and a dynamic IP will ' +
@@ -279,7 +279,7 @@ elif setup_static_ip.lower() is 'y':
 
         sys.exit()
 
-    elif setup_gateway.lower() is 'y':
+    elif setup_gateway.lower() == 'y':
 
         # Ask for the gateway identifier.
         gateway_id = raw_input('\nWhat is your gateway identifier?: ')
@@ -300,7 +300,7 @@ elif setup_static_ip.lower() is 'y':
     If the response is a yes, update the interfaces file to include the DNS
     server names and the relevant functionality.
     '''
-    if setup_dns_server.lower() is 'n':
+    if setup_dns_server.lower() == 'n':
 
         # Ask the user if they would like to keep the changes to the network
         # interfaces file.
@@ -314,7 +314,7 @@ elif setup_static_ip.lower() is 'y':
         If the response is a no (or anything else), restore the backup to the
         network interfaces file.
         '''
-        if keep_changes.lower() is 'y':
+        if keep_changes.lower() == 'y':
 
             print('\nA static IP has not been set (requires a netmask, ' +
                   'a gateway, and DNS server names) and a dynamic IP will ' +
@@ -338,7 +338,7 @@ elif setup_static_ip.lower() is 'y':
 
         sys.exit()
 
-    elif setup_dns_server.lower() is 'y':
+    elif setup_dns_server.lower() == 'y':
 
         # Ask for the DNS server names.
         dns_server_1 = raw_input('\nWhat is the IP of the first DNS ' +
@@ -372,7 +372,7 @@ interfaces file has been updated.
 If the response is a no (or anything else), restore the backup to the
 network interfaces file.
 '''
-if keep_changes.lower() is 'y':
+if keep_changes.lower() == 'y':
 
     print('\nA static IP has been set with your indicated netmask, gateway, ' +
           'and DNS server name identifiers. Your Pi-hat sensor module now ' +

--- a/station-update.py
+++ b/station-update.py
@@ -66,7 +66,28 @@ def interfaces_update(rep_phrase, new_line):
     sys.stdout = temp_out
 
 '''
-Part 2: Securely copy the network configuration file from the Dosenet
+Part 2: Define a function to restore the backup of the interfaces file.
+'''
+
+
+def backup_restore():
+    """Function to restore the interfaces file with the backup."""
+    '''
+    Restore the backup interfaces file using the cp linux command
+    with root access.
+    '''
+    os.system('sudo cp /etc/network/interfaces_backup ' +
+              '/etc/network/interfaces')
+
+    # Alert the user that the backup interfaces file has been restored
+    # and to re-run the script if they want to re-setup the network
+    # configuration.
+    print('\nThe network interfaces file has been restored from the ' +
+          'backup and changes have been reverted. Run this Python ' +
+          'script again to setup the network configuration again.')
+
+'''
+Part 3: Securely copy the network configuration file from the Dosenet
         servers to the Pi-hat.
 '''
 
@@ -86,7 +107,7 @@ targetPath = '/home/pi/config/config.csv'
 os.system('scp {} {}'.format(sourcePath, targetPath))
 
 '''
-Part 3: Update the dosimeter ID on the network configuration file on the
+Part 4: Update the dosimeter ID on the network configuration file on the
         Pi-hat once it has been copied securely over the Internet.
 '''
 
@@ -167,17 +188,8 @@ if setup_static_ip.lower() == 'n':
 
     elif keep_changes.lower() == 'n':
 
-        # Restore the backup interfaces file using the cp linux command
-        # with root access.
-        os.system('sudo cp /etc/network/interfaces_backup ' +
-                  '/etc/network/interfaces')
-
-        # Alert the user that the backup interfaces file has been restored
-        # and to re-run the script if they want to re-setup the network
-        # configuration.
-        print('\nThe network interfaces file has been restored from the ' +
-              'backup and changes have been reverted. Run this Python ' +
-              'script again to setup the network configuration again.')
+        # Restore the backup for the interfaces file.
+        backup_restore()
 
     sys.exit()
 
@@ -257,17 +269,8 @@ elif setup_static_ip.lower() == 'y':
 
         elif setup_netmask.lower() == 'n':
 
-            # Restore the backup interfaces file using the cp linux command
-            # with root access.
-            os.system('sudo cp /etc/network/interfaces_backup ' +
-                      '/etc/network/interfaces')
-
-            # Alert the user that the backup interfaces file has been restored
-            # and to re-run the script if they want to re-setup the network
-            # configuration.
-            print('\nThe network interfaces file has been restored from the ' +
-                  'backup and changes have been reverted. Run this Python ' +
-                  'script again to setup the network configuration again.')
+            # Restore the backup for the interfaces file.
+            backup_restore()
 
         sys.exit()
 
@@ -347,17 +350,8 @@ elif setup_static_ip.lower() == 'y':
 
         elif keep_changes.lower() == 'n':
 
-            # Restore the backup interfaces file using the cp linux command
-            # with root access.
-            os.system('sudo cp /etc/network/interfaces_backup ' +
-                      '/etc/network/interfaces')
-
-            # Alert the user that the backup interfaces file has been restored
-            # and to re-run the script if they want to re-setup the network
-            # configuration.
-            print('\nThe network interfaces file has been restored from the ' +
-                  'backup and changes have been reverted. Run this Python ' +
-                  'script again to setup the network configuration again.')
+            # Restore the backup for the interfaces file.
+            backup_restore()
 
         sys.exit()
 
@@ -441,17 +435,8 @@ elif setup_static_ip.lower() == 'y':
 
         elif keep_changes.lower() == 'n':
 
-            # Restore the backup interfaces file using the cp linux command
-            # with root access.
-            os.system('sudo cp /etc/network/interfaces_backup ' +
-                      '/etc/network/interfaces')
-
-            # Alert the user that the backup interfaces file has been restored
-            # and to re-run the script if they want to re-setup the network
-            # configuration.
-            print('\nThe network interfaces file has been restored from the ' +
-                  'backup and changes have been reverted. Run this Python ' +
-                  'script again to setup the network configuration again.')
+            # Restore the backup for the interfaces file.
+            backup_restore()
 
         sys.exit()
 
@@ -469,7 +454,7 @@ elif setup_static_ip.lower() == 'y':
                           "{} {}".format(dns_server_1, dns_server_2) + '\n')
 
 '''
-Part 4: Perform a final check on whether the user wants to keep the changes
+Part 5: Perform a final check on whether the user wants to keep the changes
         to the interfaces file and output the results of the configuration of
         a static IP if the script has not been exited at this point.
 '''
@@ -507,14 +492,5 @@ if keep_changes.lower() == 'y':
 
 elif keep_changes.lower() == 'n':
 
-    # Restore the backup interfaces file using the cp linux command
-    # with root access.
-    os.system('sudo cp /etc/network/interfaces_backup ' +
-              '/etc/network/interfaces')
-
-    # Alert the user that the backup interfaces file has been restored
-    # and to re-run the script if they want to re-setup the network
-    # configuration.
-    print('\nThe network interfaces file has been restored from the ' +
-          'backup and changes have been reverted. Run this Python ' +
-          'script again to setup the network configuration again.')
+    # Restore the backup for the interfaces file.
+    backup_restore()

--- a/station-update.py
+++ b/station-update.py
@@ -112,6 +112,8 @@ while csv_copy.lower() != 'y' or 'n':
     # Let the user know a valid response is required for the question.
     print('Please provide a valid "y" or "n" response.')
 
+    print(csv_copy)
+
     # Ask the user if they would like to copy a new network configuration file
     # from the LBNL servers.
     csv_copy = raw_input('\nWould you like to copy a new network ' +

--- a/station-update.py
+++ b/station-update.py
@@ -25,7 +25,7 @@ sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
 targetPath = '/home/pi/config/config.csv'
 
 # Execute the linux command line to securely copy the file over the Internet.
-p = os.system('scp "%s" "%s"' % (sourcePath, targetPath))
+p = os.system('sudo scp "%s" "%s"' % (sourcePath, targetPath))
 
 # Print the scp linux command that was executed for debugging purposes.
 print 'FOR DEBUGGING, linux command: %s' % p

--- a/station-update.py
+++ b/station-update.py
@@ -1,26 +1,30 @@
 # Author: Yaro Kaminskiy
 
-# Use the built-in subprocess module and Popen function to securely copy the Pi-hat network configuration file from the Dosenet servers
-# to a Pi-hat at a school of interest and to update the network ID on the network configuration file for a Pi-hat using a search algorithm.
+'''
+This script securely copies the Pi-hat network configuration file from the Dosenet servers to a Pi-hat at a school of interest and
+updates the network ID on the network configuration file for the Pi-hat.
+'''
+
+# Import the relevant modules and functions from the appropriate libraries for convenience.
+import fileinput
+import sys
+import os
 
 '''
 Part 1: Securely copying the network configuration file from the Dosenet servers to the Pi-hat.
 '''
 
-# Import the relevant modules and functions from the appropriate libraries for convenience. 
-import os
-
-# Ask the user for the csv file name.
+# Ask the user for the csv file name and output the raw input string as a variable.
 NAME = raw_input('What is the csv file name?: ')
 
 # Print the csv file name inputed by the user for debugging purposes.
 print 'FOR DEGUBBING, csv file name: %s' % NAME
 
-# Define the paths to the source and target .csv files as arguments for the scp linux command to be executed through the Popen function.
+# Define the paths to the source and target .csv files as arguments for the scp linux command to be executed through the os.sytem function.
 sourcePath = 'dosenet@dosenet.dhcp.lbl.gov:~/config-files/' + NAME
 targetPath = '/home/pi/config/config.csv'
 
-# Execute the linux command line to securely copy the file over the Internet. Wait until it executes for this Python script to continue.
+# Execute the linux command line to securely copy the file over the Internet.
 p = os.system('scp "%s" "%s"' % (sourcePath, targetPath))
 
 # Print the scp linux command that was executed for debugging purposes.
@@ -30,40 +34,18 @@ print 'FOR DEBUGGING, linux command: %s' % p
 Part 2: Updating the dosimeter ID on the network configuration file on the Pi-hat once it has been copied securely over the Internet.
 '''
 
-# Ask for the station ID.
+# Ask for the station ID and output the raw input string as a variable.
 ID = raw_input('What is the station ID?: ')
 
-# Open the interfaces file (and call a file handle for it within the program) and update the network ID.
-with open('/etc/network/interfaces', 'r+') as netConfig:
-  # Search line by line in the interfaces file.
-  for line in netConfig:
-    # Search for 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
-    if 'wireless-essid' in line:
-      # Create a handle for a new line with the updated station ID to input into the interfaces file.      
-      line = 'wireless-essid RPiAdHocNetwork' + ID + '\n'
-      netConfig.write(line)
-
-
 '''
-Optional backup section, only works with Python 3.3 and later.
-
-# Open the relevant directory to read/write the network ID on the Pi-hat.
-dirConfig = os.open('/etc/network/interfaces')
-
-# Define a function to open files within the directory of interest.
-def opendir(path, flags):
-  return os.open(path, flags, dir_fd=dirConfig)
-
-# Open the interfaces file (and call a file handle for it within the program) and update the network ID.
-with open('interfaces', '+', opener=opendir) as netConfig:
-  # Search line by line in the interfaces file.
-  for line in netConfig:
-    # Search for 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
-    if 'wireless-essid' in line:
-      # Create a handle for a new line with the updated station ID to input into the interfaces file.      
-      line = 'wireless-essid RPiAdHocNetwork' + ID + '\n'
-      netConfig.write(line)
-
-# Close the file directory.
-os.close(dirConfig)
+Loop through each line of the interfaces file to find the default station ID placeholder and replace it with the station ID provided
+by the user.
 '''
+for line in fileinput.input('/etc/network/interfaces', inplace=1):
+    # Search and find 'wireless-essid' to indicate the place in the code to replace the default Pi-hat ID with the actual station's ID.
+    if 'wireless-essid' in line:
+        # Create a handle for a new line with the updated station ID to input into the interfaces file.      
+        line = '  wireless-essid RPiAdHocNetwork' + ID + '\n'
+    
+    # Write the new line with the updated station ID in the interfaces file.
+    sys.stdout.write(line)

--- a/station-update.py
+++ b/station-update.py
@@ -2,7 +2,7 @@
 Network config updater for a DoseNet silicon radiation detector station.
 
 This script securely copies the Pi-hat network configuration file from the
-Dosenet servers to a Pi-hat at a school of interest and updates the network ID
+DoseNet servers to a Pi-hat at a school of interest and updates the network ID
 on the network configuration file for the Pi-hat, as well as handles netmasks,
 gateways, and DNS server names to setup a static IP if necessary. (A dynamic
 IP is set by default.)
@@ -112,12 +112,23 @@ interfaces_update('wireless-essid RPiAdHocNetwork', '  wireless-essid ' +
 setup_static_ip = raw_input('\nDo you want to set a static IP (y/n)?: ')
 
 '''
+If there is no valid response, let the user know and repeat the prompt until a
+valid response is provided.
+
 If the response is a no, ask additionally if the the user would like to keep
 the changes done to the network interfaces file.
 
 If the response is a yes, update the interfaces file to include the static IP
 and the relevant functionality.
 '''
+
+while setup_static_ip.lower() != 'y' or 'n':
+
+    # Let the user know a valid response is required for the question.
+    print('Please provide a valid "y" or "n" response.')
+
+    # Re-ask the user if they would like to use a static IP.
+    setup_static_ip = raw_input('\nDo you want to set a static IP (y/n)?: ')
 
 if setup_static_ip.lower() == 'n':
 
@@ -127,19 +138,34 @@ if setup_static_ip.lower() == 'n':
                              '(y/n)?: ')
 
     '''
+    If there is no valid response, let the user know and repeat the prompt
+    until a valid response is provided.
+
     If the response is a yes, exit the script and tell the user the network
     interfaces file has been updated.
 
     If the response is a no (or anything else), restore the backup to the
     network interfaces file.
     '''
+
+    while keep_changes.lower() != 'y' or 'n':
+
+        # Let the user know a valid response is required for the question.
+        print('Please provide a valid "y" or "n" response.')
+
+        # Ask the user if they would like to keep the changes to the network
+        # interfaces file.
+        keep_changes = raw_input('\nWould you like to keep these changes ' +
+                                 '(y/n)?: ')
+
     if keep_changes.lower() == 'y':
 
         print('\nA dynamic IP has been set. Your Pi-hat sensor module now ' +
               'has updated network functionality and the appropriate ' +
-              'network interfaces file has been copied over the server.')
+              'network interfaces file has been copied over from the ' +
+              'DoseNet servers.')
 
-    else:
+    elif keep_changes.lower() == 'n':
 
         # Restore the backup interfaces file using the cp linux command
         # with root access.
@@ -174,12 +200,24 @@ elif setup_static_ip.lower() == 'y':
     setup_netmask = raw_input('\nDo you have a netmask (y/n)?: ')
 
     '''
+    If there is no valid response, let the user know and repeat the prompt
+    until a valid response is provided.
+
     If the response is a no, ask additionally if the the user would like to
     keep the changes done to the network interfaces file.
 
     If the response is a yes, update the interfaces file to include the netmask
     identifier and the relevant functionality.
     '''
+
+    while setup_netmask.lower() != 'y' or 'n':
+
+        # Let the user know a valid response is required for the question.
+        print('Please provide a valid "y" or "n" response.')
+
+        # Ask the user if they have a netmask.
+        setup_netmask = raw_input('\nDo you have a netmask (y/n)?: ')
+
     if setup_netmask.lower() == 'n':
 
         # Ask the user if they would like to keep the changes to the network
@@ -188,21 +226,36 @@ elif setup_static_ip.lower() == 'y':
                                  '(y/n)?: ')
 
         '''
+        If there is no valid response, let the user know and repeat the prompt
+        until a valid response is provided.
+
         If the response is a yes, exit the script and tell the user the network
         interfaces file has been updated.
 
         If the response is a no (or anything else), restore the backup to the
         network interfaces file.
         '''
+
+        while keep_changes.lower() != 'y' or 'n':
+
+            # Let the user know a valid response is required for the question.
+            print('Please provide a valid "y" or "n" response.')
+
+            # Ask the user if they would like to keep the changes to the
+            # network interfaces file.
+            keep_changes = raw_input('\nWould you like to keep these ' +
+                                     'changes (y/n)?: ')
+
         if keep_changes.lower() == 'y':
 
             print('\nA static IP has not been set (requires a netmask, ' +
                   'a gateway, and DNS server names) and a dynamic IP will ' +
                   'remain. Your Pi-hat sensor module now has updated ' +
                   'network functionality and the appropriate network ' +
-                  'interfaces file has been copied over the server.')
+                  'interfaces file has been copied over from the DoseNet ' +
+                  'servers.')
 
-        else:
+        elif setup_netmask.lower() == 'n':
 
             # Restore the backup interfaces file using the cp linux command
             # with root access.
@@ -232,12 +285,24 @@ elif setup_static_ip.lower() == 'y':
     setup_gateway = raw_input('\nDo you have a gateway (y/n)?: ')
 
     '''
+    If there is no valid response, let the user know and repeat the prompt
+    until a valid response is provided.
+
     If the response is a no, ask additionally if the the user would like to
     keep the changes done to the network interfaces file.
 
     If the response is a yes, update the interfaces file to include the gateway
     identifier and the relevant functionality.
     '''
+
+    while setup_gateway.lower() != 'y' or 'n':
+
+        # Let the user know a valid response is required for the question.
+        print('Please provide a valid "y" or "n" response.')
+
+        # Ask the user if they have a gateway.
+        setup_gateway = raw_input('\nDo you have a gateway (y/n)?: ')
+
     if setup_gateway.lower() == 'n':
 
         # Ask the user if they would like to keep the changes to the network
@@ -246,21 +311,41 @@ elif setup_static_ip.lower() == 'y':
                                  '(y/n)?: ')
 
         '''
+        If there is no valid response, let the user know and repeat the prompt
+        until a valid response is provided.
+
         If the response is a yes, exit the script and tell the user the network
         interfaces file has been updated.
 
         If the response is a no (or anything else), restore the backup to the
         network interfaces file.
         '''
+
+        while keep_changes.lower() != 'y' or 'n':
+
+            # Let the user know a valid response is required for the question.
+            print('Please provide a valid "y" or "n" response.')
+
+            # Ask the user if they would like to keep the changes to the
+            # network interfaces file.
+            keep_changes = raw_input('\nWould you like to keep these ' +
+                                     'changes (y/n)?: ')
+
         if keep_changes.lower() == 'y':
+
+            # Update the interfaces file with the netmask identifier by
+            # commenting out the netmask call.
+            interfaces_update('  netmask {}'.format(netmask_id), '#   ' +
+                              'netmask\n')
 
             print('\nA static IP has not been set (requires a netmask, ' +
                   'a gateway, and DNS server names) and a dynamic IP will ' +
                   'remain. Your Pi-hat sensor module now has updated ' +
                   'network functionality and the appropriate network ' +
-                  'interfaces file has been copied over the server.')
+                  'interfaces file has been copied over from the DoseNet ' +
+                  'servers.')
 
-        else:
+        elif keep_changes.lower() == 'n':
 
             # Restore the backup interfaces file using the cp linux command
             # with root access.
@@ -291,12 +376,24 @@ elif setup_static_ip.lower() == 'y':
                                  '(y/n)?: ')
 
     '''
+    If there is no valid response, let the user know and repeat the prompt
+    until a valid response is provided.
+
     If the response is a no, ask additionally if the the user would like to
     keep the changes done to the network interfaces file.
 
     If the response is a yes, update the interfaces file to include the DNS
     server names and the relevant functionality.
     '''
+    while setup_dns_server.lower() != 'y' or 'n':
+
+        # Let the user know a valid response is required for the question.
+        print('Please provide a valid "y" or "n" response.')
+
+        # Ask the user if they have DNS servers connected.
+        setup_dns_server = raw_input('\nDo you have DNS servers connected ' +
+                                     '(y/n)?: ')
+
     if setup_dns_server.lower() == 'n':
 
         # Ask the user if they would like to keep the changes to the network
@@ -305,21 +402,44 @@ elif setup_static_ip.lower() == 'y':
                                  '(y/n)?: ')
 
         '''
+        If there is no valid response, let the user know and repeat the prompt
+        until a valid response is provided.
+
         If the response is a yes, exit the script and tell the user the network
         interfaces file has been updated.
 
         If the response is a no (or anything else), restore the backup to the
         network interfaces file.
         '''
+
+        while keep_changes.lower() != 'y' or 'n':
+
+            # Let the user know a valid response is required for the question.
+            print('Please provide a valid "y" or "n" response.')
+
+            # Ask the user if they would like to keep the changes to the
+            # network interfaces file.
+            keep_changes = raw_input('\nWould you like to keep these ' +
+                                     'changes (y/n)?: ')
+
         if keep_changes.lower() == 'y':
+
+            # Remove the netmask and gateway identifiers from the interfaces
+            # file by commenting them out.
+            interfaces_update('  netmask {}'.format(netmask_id), '#   ' +
+                              'netmask\n')
+
+            interfaces_update('  gateway {}'.format(gateway_id), '#   ' +
+                              'gateway\n')
 
             print('\nA static IP has not been set (requires a netmask, ' +
                   'a gateway, and DNS server names) and a dynamic IP will ' +
                   'remain. Your Pi-hat sensor module now has updated ' +
                   'network functionality and the appropriate network ' +
-                  'interfaces file has been copied over the server.')
+                  'interfaces file has been copied over from the DoseNet ' +
+                  'servers.')
 
-        else:
+        elif keep_changes.lower() == 'n':
 
             # Restore the backup interfaces file using the cp linux command
             # with root access.
@@ -348,10 +468,6 @@ elif setup_static_ip.lower() == 'y':
         interfaces_update("#   dns-nameservers", "  dns-nameservers " +
                           "{} {}".format(dns_server_1, dns_server_2) + '\n')
 
-else:
-
-    sys.exit()
-
 '''
 Part 4: Perform a final check on whether the user wants to keep the changes
         to the interfaces file and output the results of the configuration of
@@ -363,20 +479,33 @@ Part 4: Perform a final check on whether the user wants to keep the changes
 keep_changes = raw_input('\nWould you like to keep these changes (y/n)?: ')
 
 '''
+If there is no valid response, let the user know and repeat the prompt
+until a valid response is provided.
+
 If the response is a yes, exit the script and tell the user the network
 interfaces file has been updated.
 
 If the response is a no (or anything else), restore the backup to the
 network interfaces file.
 '''
+
+while keep_changes.lower() != 'y' or 'n':
+
+    # Let the user know a valid response is required for the question.
+    print('Please provide a valid "y" or "n" response.')
+
+    # Re-ask the user if they would like to keep the changes to the network
+    # interfaces file.
+    keep_changes = raw_input('\nWould you like to keep these changes (y/n)?: ')
+
 if keep_changes.lower() == 'y':
 
     print('\nA static IP has been set with your indicated netmask, gateway, ' +
           'and DNS server name identifiers. Your Pi-hat sensor module now ' +
           'has updated network functionality and the appropriate network ' +
-          'interfaces file has been copied over the server.')
+          'interfaces file has been copied over from the DoseNet servers.')
 
-else:
+elif keep_changes.lower() == 'n':
 
     # Restore the backup interfaces file using the cp linux command
     # with root access.

--- a/station-update.py
+++ b/station-update.py
@@ -14,12 +14,12 @@ from subprocess import Popen
 # Ask the user for the csv file name.
 NAME = input("What is the csv file name?:")
 
-print NAME,"csv file name"
+print ("csv file name: ", NAME)
 
 # Execute the linux command line and wait until it executes for the script to continue.
 p = Popen("scp", "dosenet@dosenet.dhcp.lbl.gov:~/config-files/", NAME, "/home/pi/config/config.csv").wait()
 
-print (p, "linux command")
+print ("linux command: ", p)
 
 # Ask for the station ID.
 ID = input("What is the station ID?:")


### PR DESCRIPTION
Major update and rewrite of the network configuration file into the Python scripting language for accessibility, readability, and update-ability. Copying the config.csv file from the LBL servers to the Pi hat is successfully working.

Updating the station ID on the network interfaces file still needs work. It is near full functionality but hasn't been fully tested/debugged. It is expected that the last update to the code will work fully, but it needs to be tested. METHOD 1 in the interfacesUpdate function is short, simple, and sweet but does not work! The interfaces file is left blank, suggesting a root access problem of copying the interfaces problem even with the use of the sudo command, similar to what METHOD 2 had before that was debugged. METHOD 2 fully worked before extra functionality was added (explained later in this description). Now the raw_input functions simply print the statement they are asking of the user and does not return the input from the user! Saving and returning the standard input was added just now to address this, but has not been tested yet. So METHOD 2 will most likely be utilized after full testing and debugging. (Note: There are two random print statements in the code that print the input from the user. They were used for debugging.)

The extra functionality that this script will have over the bash network configuration script is that it adds the ability to add a static IP and netmask, gateway, and DNS server identifiers. This is a relatively simple addition, but the interfacesUpdate function must work for this extra functionality to work.